### PR TITLE
feat: Add opencensus client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,11 @@ lazy val opentelemetry =
     .settings(stdSettings("zio-opentelemetry"))
     .settings(libraryDependencies := Dependencies.opentelemetry)
 
+lazy val opencensus = project
+  .in(file("opencensus"))
+  .settings(stdSettings("zio-opencensus"))
+  .settings(libraryDependencies := Dependencies.opencensus)
+
 lazy val opentracingExample =
   project
     .in(file("opentracing-example"))

--- a/opencensus/src/main/scala/zio/telemetry/opencensus/Attribute.scala
+++ b/opencensus/src/main/scala/zio/telemetry/opencensus/Attribute.scala
@@ -1,0 +1,21 @@
+package zio.telemetry.opencensus
+
+import io.opencensus.trace.AttributeValue
+
+object Attributes {
+  trait implicits {
+    import scala.language.implicitConversions
+
+    implicit def boolToAttribute(b: Boolean): AttributeValue =
+      AttributeValue.booleanAttributeValue(b)
+
+    implicit def stringToAttribute(s: String): AttributeValue =
+      AttributeValue.stringAttributeValue(s)
+
+    implicit def longToAttribute(l: Long): AttributeValue =
+      AttributeValue.longAttributeValue(l)
+
+    implicit def doubleToAttribute(d: Double): AttributeValue =
+      AttributeValue.doubleAttributeValue(d)
+  }
+}

--- a/opencensus/src/main/scala/zio/telemetry/opencensus/Live.scala
+++ b/opencensus/src/main/scala/zio/telemetry/opencensus/Live.scala
@@ -35,7 +35,6 @@ class Live(tracer: Tracer, root: FiberRef[Span]) extends Tracing.Service {
       res <- createSpan(parent, name, kind).use(
               finalizeSpanUsingEffect(
                 putAttributes(attributes) *> effect,
-                _,
                 toErrorStatus
               )
             )
@@ -51,7 +50,6 @@ class Live(tracer: Tracer, root: FiberRef[Span]) extends Tracing.Service {
       res <- createSpan(BlankSpan.INSTANCE, name, kind).use(
               finalizeSpanUsingEffect(
                 putAttributes(attributes) *> effect,
-                _,
                 toErrorStatus
               )
             )
@@ -68,7 +66,6 @@ class Live(tracer: Tracer, root: FiberRef[Span]) extends Tracing.Service {
       res <- createSpanFromRemote(remote, name, kind).use(
               finalizeSpanUsingEffect(
                 putAttributes(attributes) *> effect,
-                _,
                 toErrorStatus
               )
             )
@@ -114,9 +111,8 @@ class Live(tracer: Tracer, root: FiberRef[Span]) extends Tracing.Service {
 
   private def finalizeSpanUsingEffect[R, E, A](
     effect: ZIO[R, E, A],
-    span: Span,
     toErrorStatus: ErrorMapper[E]
-  ): ZIO[R, E, A] =
+  )(span: Span): ZIO[R, E, A] =
     for {
       r <- currentSpan_
             .locally(span)(effect)

--- a/opencensus/src/main/scala/zio/telemetry/opencensus/Live.scala
+++ b/opencensus/src/main/scala/zio/telemetry/opencensus/Live.scala
@@ -1,0 +1,165 @@
+package zio.telemetry.opencensus
+
+import zio._
+
+import io.opencensus.trace.AttributeValue
+import io.opencensus.trace.BlankSpan
+import io.opencensus.trace.Span
+import io.opencensus.trace.SpanContext
+import io.opencensus.trace.Status
+import io.opencensus.trace.propagation.TextFormat
+import io.opencensus.trace.Tracer
+
+object Live {
+  private def managed(tracer: Tracer, root: Span): ZManaged[
+    Any,
+    Nothing,
+    Live
+  ] = {
+    def end(tracing: Tracing.Service): UIO[Unit] =
+      tracing.end()
+
+    val tracing = for {
+      rootRef <- FiberRef.make[Span](root)
+    } yield new Live(tracer, rootRef)
+
+    ZManaged.make(tracing)(end)
+  }
+
+  val live: ZLayer[Has[Tracer], Nothing, Tracing] =
+    ZLayer.fromManaged(for {
+      tracer  <- ZIO.access[Has[Tracer]](_.get).toManaged_
+      service <- managed(tracer, BlankSpan.INSTANCE)
+    } yield service)
+}
+
+class Live(tracer: Tracer, root: FiberRef[Span]) extends Tracing.Service {
+  val currentSpan_ = root
+
+  def currentSpan: ZIO[Any, Nothing, Span] = currentSpan_.get
+
+  def span[R, E, A](
+    name: String,
+    kind: Span.Kind = Span.Kind.SERVER,
+    toErrorStatus: ErrorMapper[E],
+    attributes: Map[String, AttributeValue]
+  )(effect: ZIO[R, E, A]): ZIO[R, E, A] =
+    for {
+      parent <- currentSpan_.get
+      res <- createSpan(parent, name, kind).use(
+              finalizeSpanUsingEffect(
+                putAttributes(attributes) *> effect,
+                _,
+                toErrorStatus
+              )
+            )
+    } yield res
+
+  def root[R, E, A](
+    name: String,
+    kind: Span.Kind,
+    toErrorStatus: ErrorMapper[E],
+    attributes: Map[String, AttributeValue]
+  )(effect: ZIO[R, E, A]): ZIO[R, E, A] =
+    for {
+      res <- createSpan(BlankSpan.INSTANCE, name, kind).use(
+              finalizeSpanUsingEffect(
+                putAttributes(attributes) *> effect,
+                _,
+                toErrorStatus
+              )
+            )
+    } yield res
+
+  def fromRemoteSpan[R, E, A](
+    remote: SpanContext,
+    name: String,
+    kind: Span.Kind,
+    toErrorStatus: ErrorMapper[E],
+    attributes: Map[String, AttributeValue]
+  )(effect: ZIO[R, E, A]): ZIO[R, E, A] =
+    for {
+      res <- createSpanFromRemote(remote, name, kind).use(
+              finalizeSpanUsingEffect(
+                putAttributes(attributes) *> effect,
+                _,
+                toErrorStatus
+              )
+            )
+    } yield res
+
+  def putAttributes(
+    attributes: Map[String, AttributeValue]
+  ): ZIO[Any, Nothing, Unit] =
+    for {
+      current <- currentSpan_.get
+      _ <- UIO(attributes.foreach({
+            case ((k, v)) => current.putAttribute(k, v)
+          }))
+    } yield ()
+
+  private def createSpan(
+    parent: Span,
+    name: String,
+    kind: Span.Kind
+  ): UManaged[Span] =
+    ZManaged.make(
+      UIO(
+        tracer
+          .spanBuilderWithExplicitParent(name, parent)
+          .setSpanKind(kind)
+          .startSpan()
+      )
+    )(span => UIO(span.end))
+
+  private def createSpanFromRemote(
+    parent: SpanContext,
+    name: String,
+    kind: Span.Kind
+  ): UManaged[Span] =
+    ZManaged.make(
+      UIO(
+        tracer
+          .spanBuilderWithRemoteParent(name, parent)
+          .setSpanKind(kind)
+          .startSpan()
+      )
+    )(span => UIO(span.end))
+
+  private def finalizeSpanUsingEffect[R, E, A](
+    effect: ZIO[R, E, A],
+    span: Span,
+    toErrorStatus: ErrorMapper[E]
+  ): ZIO[R, E, A] =
+    for {
+      r <- currentSpan_
+            .locally(span)(effect)
+            .tapCause(setErrorStatus(span, _, toErrorStatus))
+    } yield r
+
+  def inject[C, R, E, A](
+    format: TextFormat,
+    carrier: C,
+    setter: TextFormat.Setter[C]
+  ): UIO[Unit] =
+    for {
+      current <- currentSpan
+      _       <- URIO(format.inject(current.getContext(), carrier, setter))
+    } yield ()
+
+  private[opencensus] def end: UIO[Unit] =
+    for {
+      span <- currentSpan_.get
+      _    <- UIO(span.end())
+    } yield ()
+
+  private def setErrorStatus[E](
+    span: Span,
+    cause: Cause[E],
+    toErrorStatus: ErrorMapper[E]
+  ): UIO[Unit] = {
+    val errorStatus =
+      cause.failureOption.flatMap(toErrorStatus.lift).getOrElse(Status.UNKNOWN)
+    UIO(span.setStatus(errorStatus))
+  }
+}

--- a/opencensus/src/main/scala/zio/telemetry/opencensus/Tracing.scala
+++ b/opencensus/src/main/scala/zio/telemetry/opencensus/Tracing.scala
@@ -1,0 +1,108 @@
+package zio.telemetry.opencensus
+
+import zio._
+
+import io.opencensus.trace.Span
+import io.opencensus.trace.AttributeValue
+import io.opencensus.trace.SpanContext
+import io.opencensus.trace.propagation.TextFormat
+
+object Tracing {
+  def defaultMapper[E]: ErrorMapper[E] = Map.empty
+
+  trait Service {
+    def span[R, E, A](
+      name: String,
+      kind: Span.Kind = null,
+      toErrorStatus: ErrorMapper[E] = defaultMapper[E],
+      attributes: Map[String, AttributeValue] = Map()
+    )(effect: ZIO[R, E, A]): ZIO[R, E, A]
+
+    def root[R, E, A](
+      name: String,
+      kind: Span.Kind = null,
+      toErrorStatus: ErrorMapper[E] = defaultMapper[E],
+      attributes: Map[String, AttributeValue] = Map()
+    )(effect: ZIO[R, E, A]): ZIO[R, E, A]
+
+    def fromRemoteSpan[R, E, A](
+      remote: SpanContext,
+      name: String,
+      kind: Span.Kind = Span.Kind.SERVER,
+      toErrorStatus: ErrorMapper[E] = defaultMapper[E],
+      attributes: Map[String, AttributeValue] = Map()
+    )(effect: ZIO[R, E, A]): ZIO[R, E, A]
+
+    def inject[C, R, E, A](
+      format: TextFormat,
+      carrier: C,
+      setter: TextFormat.Setter[C]
+    ): UIO[Unit]
+
+    def putAttributes(
+      attrs: Map[String, AttributeValue]
+    ): ZIO[Any, Nothing, Unit]
+
+    private[opencensus] def end(): UIO[Unit]
+  }
+
+  def span[R, E, A](
+    name: String,
+    kind: Span.Kind = null,
+    toErrorStatus: ErrorMapper[E] = defaultMapper[E],
+    attributes: Map[String, AttributeValue] = Map()
+  )(effect: ZIO[R, E, A]): ZIO[R with Tracing, E, A] =
+    ZIO.accessM(_.get.span(name, kind, toErrorStatus, attributes)(effect))
+
+  def root[R, E, A](
+    name: String,
+    kind: Span.Kind = null,
+    toErrorStatus: ErrorMapper[E] = defaultMapper[E],
+    attributes: Map[String, AttributeValue] = Map()
+  )(effect: ZIO[R, E, A]): ZIO[R with Tracing, E, A] =
+    ZIO.accessM(_.get.root(name, kind, toErrorStatus, attributes)(effect))
+
+  def fromRemoteSpan[R, E, A](
+    remote: SpanContext,
+    name: String,
+    kind: Span.Kind = null,
+    toErrorStatus: ErrorMapper[E] = defaultMapper[E],
+    attributes: Map[String, AttributeValue] = Map()
+  )(effect: ZIO[R, E, A]): ZIO[R with Tracing, E, A] =
+    ZIO.accessM(
+      _.get.fromRemoteSpan(remote, name, kind, toErrorStatus, attributes)(
+        effect
+      )
+    )
+
+  def putAttributes(
+    attributes: (String, AttributeValue)*
+  ): ZIO[Tracing, Nothing, Unit] =
+    ZIO.accessM(_.get.putAttributes(attributes.toMap))
+
+  def withAttributes[R, E, A](
+    attributes: (String, AttributeValue)*
+  )(eff: ZIO[R, E, A]): ZIO[R with Tracing, E, A] =
+    ZIO.accessM[Tracing](_.get.putAttributes(attributes.toMap)) *> eff
+
+  def fromRootSpan[C, R, E, A](
+    format: TextFormat,
+    carrier: C,
+    getter: TextFormat.Getter[C],
+    name: String,
+    kind: Span.Kind = Span.Kind.SERVER,
+    toErrorStatus: ErrorMapper[E] = defaultMapper[E],
+    attributes: Map[String, AttributeValue] = Map()
+  )(effect: ZIO[R, E, A]): ZIO[R with Tracing, E, A] =
+    Task(format.extract(carrier, getter)).foldM(
+      _ => root(name, kind, toErrorStatus)(effect),
+      remote => fromRemoteSpan(remote, name, kind, toErrorStatus, attributes)(effect)
+    )
+
+  def inject[C, R, E, A](
+    format: TextFormat,
+    carrier: C,
+    setter: TextFormat.Setter[C]
+  ): URIO[R with Tracing, Unit] =
+    ZIO.accessM(_.get.inject(format, carrier, setter))
+}

--- a/opencensus/src/main/scala/zio/telemetry/opencensus/Tracing.scala
+++ b/opencensus/src/main/scala/zio/telemetry/opencensus/Tracing.scala
@@ -43,7 +43,7 @@ object Tracing {
       attrs: Map[String, AttributeValue]
     ): ZIO[Any, Nothing, Unit]
 
-    private[opencensus] def end(): UIO[Unit]
+    private[opencensus] def end: UIO[Unit]
   }
 
   def span[R, E, A](

--- a/opencensus/src/main/scala/zio/telemetry/opencensus/package.scala
+++ b/opencensus/src/main/scala/zio/telemetry/opencensus/package.scala
@@ -1,0 +1,11 @@
+package zio.telemetry
+
+import io.opencensus.trace.Status
+
+import zio.Has
+package object opencensus {
+  object implicits extends Attributes.implicits
+
+  type Tracing        = Has[Tracing.Service]
+  type ErrorMapper[E] = PartialFunction[E, Status]
+}

--- a/opencensus/src/main/scala/zio/telemetry/opencensus/syntax.scala
+++ b/opencensus/src/main/scala/zio/telemetry/opencensus/syntax.scala
@@ -1,0 +1,41 @@
+package zio.telemetry.opencensus
+
+import zio._
+
+import io.opencensus.trace.AttributeValue
+import io.opencensus.trace.SpanContext
+import io.opencensus.trace.Span
+
+object syntax {
+  implicit final class OpenCensusZioOps[R, E, A](val effect: ZIO[R, E, A]) extends AnyVal {
+    def span(
+      name: String,
+      kind: Span.Kind = null,
+      toErrorStatus: ErrorMapper[E] = Tracing.defaultMapper[E],
+      attributes: Map[String, AttributeValue]
+    ): ZIO[R with Tracing, E, A] =
+      Tracing.span(name, kind, toErrorStatus, attributes)(effect)
+
+    def root(
+      name: String,
+      kind: Span.Kind = null,
+      toErrorStatus: ErrorMapper[E] = Tracing.defaultMapper[E],
+      attributes: Map[String, AttributeValue]
+    ): ZIO[R with Tracing, E, A] =
+      Tracing.root(name, kind, toErrorStatus, attributes)(effect)
+
+    def fromRemoteSpan(
+      remote: SpanContext,
+      name: String,
+      kind: Span.Kind,
+      toErrorStatus: ErrorMapper[E],
+      attributes: Map[String, AttributeValue]
+    ): ZIO[R with Tracing, E, A] =
+      Tracing.fromRemoteSpan(remote, name, kind, toErrorStatus, attributes)(effect)
+
+    def withAttributes(
+      attributes: (String, AttributeValue)*
+    ): ZIO[R with Tracing, E, A] =
+      Tracing.withAttributes(attributes: _*)(effect)
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,6 +7,7 @@ object Dependencies {
     val sttp          = "2.1.1"
     val opentracing   = "0.33.0"
     val opentelemetry = "0.3.0"
+    val opencensus    = "0.26.0"
     val zipkin        = "2.15.0"
     val zio           = "1.0.0-RC19"
   }
@@ -28,6 +29,12 @@ object Dependencies {
     "io.opentelemetry"       % "opentelemetry-api"                % Versions.opentelemetry,
     "io.opentelemetry"       % "opentelemetry-exporters-inmemory" % Versions.opentelemetry % Test,
     "org.scala-lang.modules" %% "scala-collection-compat"         % "2.1.6"
+  )
+
+  lazy val opencensus = zio ++ Seq(
+    "io.opencensus" % "opencensus-api"               % Versions.opencensus,
+    "io.opencensus" % "opencensus-impl"              % Versions.opencensus,
+    "io.opencensus" % "opencensus-contrib-http-util" % Versions.opencensus
   )
 
   lazy val example = Seq(


### PR DESCRIPTION
Hi!

This adds an [OpenCensus](https://opencensus.io/) client to `zio-telemetry`. The reason I needed it was because it has great integration with [Google Cloud Trace/Stackdriver Tracing](https://cloud.google.com/trace).

It largely follows the structure of the existing clients. The difference is that the `Service` does a bit more than the current clients. This is due to the fact that I've extracted it out of an application, and there it was really useful to have an injectable service that was a bit more capable for adding tracing to other services such as a Redis client wrapper, without having the change the interfaces from e.g `get[A](key: String): ZIO[Any, Throwable, A]` to `get[A](key: String): ZIO[Tracing, Throwable, A]`.

It currently lacks tests because I haven't been able to find a good mocked or inmemory exporter that could be used for testing (looking at `opencensus-java`, it doesn't seem like just mocking the `Tracer` itself will give much).

I've chosen to hold off adding any examples awaiting https://github.com/zio/zio-telemetry/issues/106, but could quite easily extract an example on top of e.g [zio-grpc](https://github.com/scalapb/zio-grpc) which I'm currently using it with. I'm not super familiar with `http4s` but I assume adding an example for it would be pretty straight forward as well.