### PR TITLE
Add scoped effects to Tracing service.

### DIFF
--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/Tracing.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/Tracing.scala
@@ -2,6 +2,8 @@ package zio.telemetry.opentelemetry
 
 import java.util.concurrent.TimeUnit
 
+import scala.concurrent.{ ExecutionContext }
+
 import io.opentelemetry.common.Attributes
 import io.opentelemetry.context.propagation.HttpTextFormat
 import io.opentelemetry.trace.{ DefaultSpan, EndSpanOptions, Span, Status, Tracer }
@@ -17,6 +19,7 @@ object Tracing {
     private[opentelemetry] val currentSpan: FiberRef[Span]
     private[opentelemetry] def createRoot(spanName: String, spanKind: Span.Kind): UManaged[Span]
     private[opentelemetry] def createChildOf(parent: Span, spanName: String, spanKind: Span.Kind): UManaged[Span]
+    private[opentelemetry] def getTracer: UIO[Tracer]
   }
 
   private def currentNanos: URIO[Tracing, Long] =
@@ -32,6 +35,9 @@ object Tracing {
     ZManaged.accessManaged[Tracing](_.get.createChildOf(parent, spanName, spanKind))
 
   private def getCurrentSpan: URIO[Tracing, Span] = currentSpan.flatMap(_.get)
+
+  private def getTracer: URIO[Tracing, Tracer] =
+    ZIO.access[Tracing](_.get).flatMap(_.getTracer)
 
   private def toEndTimestamp(time: Long): EndSpanOptions = EndSpanOptions.builder().setEndTimestamp(time).build()
 
@@ -97,6 +103,62 @@ object Tracing {
       old <- getCurrentSpan
       r   <- createChildOf(old, spanName, spanKind).use(finalizeSpanUsingEffect(effect, _, toErrorStatus))
     } yield r
+
+  /*
+   * Introduces a thread-local scope during the execution allowing
+   * for non-zio context propagation.
+   *
+   * Closes the scope when the effect finishes.
+   */
+  def scopedEffect[R, A](effect: => A): ZIO[Tracing, Throwable, A] =
+    for {
+      currentSpan <- getCurrentSpan
+      tracer      <- getTracer
+      eff <- Task.effect {
+              val scope = tracer.withSpan(currentSpan)
+              try effect
+              finally scope.close()
+            }
+    } yield eff
+
+  /*
+   * Introduces a thread-local scope during the execution allowing
+   * for non-zio context propagation.
+   *
+   * Closes the scope when the effect finishes.
+   */
+  def scopedEffectTotal[R, A](effect: => A): ZIO[Tracing, Nothing, A] =
+    for {
+      currentSpan <- getCurrentSpan
+      tracer      <- getTracer
+      eff <- Task.effectTotal {
+              val scope = tracer.withSpan(currentSpan)
+              try effect
+              finally scope.close()
+            }
+    } yield eff
+
+  /*
+   * Introduces a thread-local scope from the currently active zio span
+   * allowing for non-zio context propagation. This scope will only be
+   * active during Future creation, so another mechanism must be used to
+   * ensure that the scope is passed into the Future callbacks.
+   *
+   * The java auto instrumentation package provides such a mechanism out of
+   * the box, so one is not provided as a part of this method.
+   *
+   * CLoses the scope when the effect finishes
+   */
+  def scopedEffectFromFuture[R, A](make: ExecutionContext => scala.concurrent.Future[A]): ZIO[Tracing, Throwable, A] =
+    for {
+      currentSpan <- getCurrentSpan
+      tracer      <- getTracer
+      eff <- ZIO.fromFuture { implicit ec =>
+              val scope = tracer.withSpan(currentSpan)
+              try make(ec)
+              finally scope.close()
+            }
+    } yield eff
 
   /**
    * Injects the current span into carrier `C`
@@ -173,6 +235,9 @@ object Tracing {
                    )
                  )(end)
         } yield span
+
+      override private[opentelemetry] def getTracer: UIO[Tracer] =
+        UIO.succeed(tracer)
 
       val currentSpan: FiberRef[Span] = defaultSpan
     }


### PR DESCRIPTION
By introducing `Tracing.scopedEffect`, `Tracing.scopedEffectTotal`
and `Tracing.scopedEffectFromFuture` it is now possible to pass spans
reliably into non-zio code, such as that generated by the java auto
instrumentation.
    
`Tracing.scopedEffectFromFuture` ensure the scope is preset at the time
the future is created, but does not currently wrap the Future executionContext 
ensuring that the context is passed since the java auto instrumentation
already handles this and it is generally the concern of the `legacy` code
rather than zio-telemetry

Fixes #207