### PR TITLE
Expose extension methods in the service

### DIFF
--- a/opentracing-example/src/main/scala/zio/telemetry/opentracing/example/http/StatusesService.scala
+++ b/opentracing-example/src/main/scala/zio/telemetry/opentracing/example/http/StatusesService.scala
@@ -30,8 +30,7 @@ object StatusesService {
       case GET -> Root / "statuses" =>
         val zio =
           for {
-            env     <- ZIO.environment[OpenTracing]
-            _       <- env.get.root("/statuses")
+            _       <- ZIO.environment[OpenTracing].root("/statuses")
             _       <- OpenTracing.tag(Tags.SPAN_KIND.getKey, Tags.SPAN_KIND_CLIENT)
             _       <- OpenTracing.tag(Tags.HTTP_METHOD.getKey, GET.name)
             _       <- OpenTracing.setBaggageItem("proxy-baggage-item-key", "proxy-baggage-item-value")

--- a/opentracing/src/main/scala/zio/telemetry/opentracing/OpenTracing.scala
+++ b/opentracing/src/main/scala/zio/telemetry/opentracing/OpenTracing.scala
@@ -20,7 +20,6 @@ object OpenTracing {
     def finish(span: Span): UIO[Unit]
     def log[R, E, A](zio: ZIO[R, E, A], fields: Map[String, _]): ZIO[R, E, A]
     def log[R, E, A](zio: ZIO[R, E, A], msg: String): ZIO[R, E, A]
-    def root(operation: String): UIO[Span]
     def root[R, E, A](zio: ZIO[R, E, A], operation: String, tagError: Boolean, logError: Boolean): ZIO[R, E, A]
     def setBaggageItem[R, E, A](zio: ZIO[R, E, A], key: String, value: String): ZIO[R, E, A]
     def span[R, E, A](zio: ZIO[R, E, A], operation: String, tagError: Boolean, logError: Boolean): ZIO[R, E, A]
@@ -59,8 +58,6 @@ object OpenTracing {
 
         def log[R, E, A](zio: ZIO[R, E, A], msg: String): ZIO[R, E, A] =
           zio <* currentSpan.get.zipWith(micros)((span, now) => span.log(now, msg))
-
-        def root(operation: String): UIO[Span] = UIO(tracer.buildSpan(operation).start())
 
         def root[R, E, A](zio: ZIO[R, E, A], operation: String, tagError: Boolean, logError: Boolean): ZIO[R, E, A] =
           for {

--- a/opentracing/src/main/scala/zio/telemetry/opentracing/OpenTracing.scala
+++ b/opentracing/src/main/scala/zio/telemetry/opentracing/OpenTracing.scala
@@ -121,13 +121,12 @@ object OpenTracing {
   def context: URIO[OpenTracing, SpanContext] =
     ZIO.accessM(_.get.currentSpan.get.map(_.context))
 
-  def getBaggageItem(key: String): URIO[OpenTracing, Option[String]] = {
+  def getBaggageItem(key: String): URIO[OpenTracing, Option[String]] =
     for {
       service <- ZIO.service[OpenTracing.Service]
       span    <- service.currentSpan.get
       res     <- ZIO.effectTotal(span.getBaggageItem(key)).map(Option(_))
     } yield res
-  }
 
   def inject[C <: AnyRef](format: Format[C], carrier: C): URIO[OpenTracing, Unit] =
     for {

--- a/opentracing/src/main/scala/zio/telemetry/opentracing/OpenTracing.scala
+++ b/opentracing/src/main/scala/zio/telemetry/opentracing/OpenTracing.scala
@@ -103,8 +103,7 @@ object OpenTracing {
   def setBaggageItem[R, E, A](zio: ZIO[R, E, A], key: String, value: String): ZIO[R with OpenTracing, E, A] =
     ZIO.accessM(_.get.setBaggageItem(zio, key, value))
 
-  def setBaggageItem(key: String, value: String): URIO[OpenTracing, Unit] =
-    getSpan.map(_.setBaggageItem(key, value)).unit
+  def setBaggageItem(key: String, value: String): URIO[OpenTracing, Unit] = setBaggageItem(ZIO.unit, key, value)
 
   def spanFrom[R, R1 <: R with OpenTracing, E, Span, C <: AnyRef](
     format: Format[C],
@@ -137,14 +136,11 @@ object OpenTracing {
   def tag[R, E, A](zio: ZIO[R, E, A], key: String, value: Boolean): ZIO[R with OpenTracing, E, A] =
     ZIO.accessM(_.get.tag(zio, key, value))
 
-  def tag(key: String, value: String): URIO[OpenTracing, Unit] =
-    getSpan.map(_.setTag(key, value)).unit
+  def tag(key: String, value: String): URIO[OpenTracing, Unit] = tag(ZIO.unit, key, value)
 
-  def tag(key: String, value: Int): URIO[OpenTracing, Unit] =
-    getSpan.map(_.setTag(key, value)).unit
+  def tag(key: String, value: Int): URIO[OpenTracing, Unit] = tag(ZIO.unit, key, value)
 
-  def tag(key: String, value: Boolean): URIO[OpenTracing, Unit] =
-    getSpan.map(_.setTag(key, value)).unit
+  def tag(key: String, value: Boolean): URIO[OpenTracing, Unit] = tag(ZIO.unit, key, value)
 
   private def getSpan: URIO[OpenTracing, Span] =
     ZIO.accessM(_.get.currentSpan.get)

--- a/opentracing/src/main/scala/zio/telemetry/opentracing/OpenTracing.scala
+++ b/opentracing/src/main/scala/zio/telemetry/opentracing/OpenTracing.scala
@@ -47,8 +47,10 @@ object OpenTracing {
         val currentSpan: FiberRef[Span] = ref
 
         def error(span: Span, cause: Cause[_], tagError: Boolean, logError: Boolean): UIO[Unit] =
-          UIO(span.setTag("error", true)).when(tagError) *>
-            UIO(span.log(Map("error.object" -> cause, "stack" -> cause.prettyPrint).asJava)).when(logError)
+          for {
+            _ <- UIO(span.setTag("error", true)).when(tagError)
+            _ <- UIO(span.log(Map("error.object" -> cause, "stack" -> cause.prettyPrint).asJava)).when(logError)
+          } yield ()
 
         def finish(span: Span): UIO[Unit] = micros.map(span.finish)
 

--- a/opentracing/src/main/scala/zio/telemetry/opentracing/OpenTracing.scala
+++ b/opentracing/src/main/scala/zio/telemetry/opentracing/OpenTracing.scala
@@ -105,7 +105,7 @@ object OpenTracing {
       Task(service.tracer.extract(format, carrier))
         .fold(_ => None, Option.apply)
         .flatMap {
-          case None          => zio
+          case None => zio
           case Some(spanCtx) =>
             for {
               current <- service.currentSpan.get

--- a/opentracing/src/main/scala/zio/telemetry/opentracing/OpenTracing.scala
+++ b/opentracing/src/main/scala/zio/telemetry/opentracing/OpenTracing.scala
@@ -63,11 +63,7 @@ object OpenTracing {
         def root(operation: String): UIO[Span] = UIO(tracer.buildSpan(operation).start())
 
         def setBaggageItem[R, E, A](zio: ZIO[R, E, A], key: String, value: String): ZIO[R, E, A] =
-          for {
-            res  <- zio
-            span <- currentSpan.get
-            _    <- UIO(span.setBaggageItem(key, value))
-          } yield res
+          zio <* currentSpan.get.map(_.setBaggageItem(key, value))
 
         def span(span: Span, operation: String): UIO[Span] =
           for {
@@ -76,25 +72,13 @@ object OpenTracing {
           } yield child
 
         def tag[R, E, A](zio: ZIO[R, E, A], key: String, value: String): ZIO[R, E, A] =
-          for {
-            res  <- zio
-            span <- currentSpan.get
-            _    <- UIO(span.setTag(key, value))
-          } yield res
+          zio <* currentSpan.get.map(_.setTag(key, value))
 
         def tag[R, E, A](zio: ZIO[R, E, A], key: String, value: Int): ZIO[R, E, A] =
-          for {
-            res  <- zio
-            span <- currentSpan.get
-            _    <- UIO(span.setTag(key, value))
-          } yield res
+          zio <* currentSpan.get.map(_.setTag(key, value))
 
         def tag[R, E, A](zio: ZIO[R, E, A], key: String, value: Boolean): ZIO[R, E, A] =
-          for {
-            res  <- zio
-            span <- currentSpan.get
-            _    <- UIO(span.setTag(key, value))
-          } yield res
+          zio <* currentSpan.get.map(_.setTag(key, value))
       }
     )(_.currentSpan.get.flatMap(span => UIO(span.finish())))
 

--- a/opentracing/src/main/scala/zio/telemetry/opentracing/OpenTracing.scala
+++ b/opentracing/src/main/scala/zio/telemetry/opentracing/OpenTracing.scala
@@ -49,7 +49,7 @@ object OpenTracing {
           } yield child
 
         override def finish(span: Span): UIO[Unit] =
-          clock.currentTime(TimeUnit.MICROSECONDS).map(span.finish)
+          getCurrentTimeMicros.map(span.finish)
 
         override def error(span: Span, cause: Cause[_], tagError: Boolean, logError: Boolean): UIO[Unit] =
           UIO(span.setTag("error", true)).when(tagError) *>

--- a/opentracing/src/main/scala/zio/telemetry/opentracing/OpenTracing.scala
+++ b/opentracing/src/main/scala/zio/telemetry/opentracing/OpenTracing.scala
@@ -120,7 +120,7 @@ object OpenTracing {
 
   def log(fields: Map[String, _]): URIO[OpenTracing, Unit] = log(ZIO.unit, fields)
 
-  def log[R, E, A](zio: ZIO[R, E, A], fields: Map[String, _]): ZIO[R with OpenTracing, E, A] = 
+  def log[R, E, A](zio: ZIO[R, E, A], fields: Map[String, _]): ZIO[R with OpenTracing, E, A] =
     ZIO.accessM(_.get.log(zio, fields))
 
   def log[R, E, A](zio: ZIO[R, E, A], msg: String): ZIO[R with OpenTracing, E, A] =

--- a/opentracing/src/main/scala/zio/telemetry/opentracing/OpenTracing.scala
+++ b/opentracing/src/main/scala/zio/telemetry/opentracing/OpenTracing.scala
@@ -28,8 +28,7 @@ object OpenTracing {
     def tag[R, E, A](zio: ZIO[R, E, A], key: String, value: Boolean): ZIO[R, E, A]
   }
 
-  val noop: URLayer[Clock, OpenTracing] =
-    live(NoopTracerFactory.create())
+  lazy val noop: URLayer[Clock, OpenTracing] = live(NoopTracerFactory.create())
 
   def live(tracer: Tracer, rootOperation: String = "ROOT"): URLayer[Clock, OpenTracing] =
     ZLayer.fromManaged(managed(tracer, rootOperation))

--- a/opentracing/src/main/scala/zio/telemetry/opentracing/package.scala
+++ b/opentracing/src/main/scala/zio/telemetry/opentracing/package.scala
@@ -71,13 +71,13 @@ package object opentracing {
       zio <* OpenTracing.setBaggageItem(key, value)
 
     def tag(key: String, value: String): ZIO[R with OpenTracing, E, A] =
-      zio <* OpenTracing.tag(key, value)
+      OpenTracing.tag(zio, key, value)
 
     def tag(key: String, value: Int): ZIO[R with OpenTracing, E, A] =
-      zio <* OpenTracing.tag(key, value)
+      OpenTracing.tag(zio, key, value)
 
     def tag(key: String, value: Boolean): ZIO[R with OpenTracing, E, A] =
-      zio <* OpenTracing.tag(key, value)
+      OpenTracing.tag(zio, key, value)
 
     def log(msg: String): ZIO[R with OpenTracing, E, A] =
       zio <* OpenTracing.log(msg)

--- a/opentracing/src/main/scala/zio/telemetry/opentracing/package.scala
+++ b/opentracing/src/main/scala/zio/telemetry/opentracing/package.scala
@@ -2,7 +2,7 @@ package zio.telemetry
 
 import io.opentracing.Span
 import io.opentracing.propagation.Format
-import zio.{ Exit, Has, IO, UIO, URIO, ZIO }
+import zio.{ Exit, Has, IO, UIO, ZIO }
 
 package object opentracing {
   type OpenTracing = Has[OpenTracing.Service]
@@ -14,11 +14,7 @@ package object opentracing {
       tagError: Boolean = true,
       logError: Boolean = true
     ): ZIO[R with OpenTracing, E, A] =
-      for {
-        service <- getService
-        root    <- service.root(operation)
-        r       <- span(service)(root, tagError, logError)
-      } yield r
+      OpenTracing.root(zio, operation, tagError, logError)
 
     def span(
       operation: String,
@@ -49,9 +45,6 @@ package object opentracing {
 
     private def getSpan(service: OpenTracing.Service): UIO[Span] =
       service.currentSpan.get
-
-    private def getService: URIO[OpenTracing, OpenTracing.Service] =
-      ZIO.service[OpenTracing.Service]
 
     def spanFrom[R1 <: R with OpenTracing, C <: Object](
       format: Format[C],

--- a/opentracing/src/main/scala/zio/telemetry/opentracing/package.scala
+++ b/opentracing/src/main/scala/zio/telemetry/opentracing/package.scala
@@ -56,7 +56,7 @@ package object opentracing {
       service.currentSpan.get
 
     private def getService: URIO[OpenTracing, OpenTracing.Service] =
-      ZIO.access[OpenTracing](_.get)
+      ZIO.service[OpenTracing.Service]
 
     def spanFrom[R1 <: R with OpenTracing, C <: Object](
       format: Format[C],

--- a/opentracing/src/main/scala/zio/telemetry/opentracing/package.scala
+++ b/opentracing/src/main/scala/zio/telemetry/opentracing/package.scala
@@ -25,12 +25,7 @@ package object opentracing {
       tagError: Boolean = true,
       logError: Boolean = true
     ): ZIO[R with OpenTracing, E, A] =
-      for {
-        service <- getService
-        old     <- getSpan(service)
-        child   <- service.span(old, operation)
-        r       <- span(service)(child, tagError, logError)
-      } yield r
+      OpenTracing.span(zio, operation, tagError, logError)
 
     def span(service: OpenTracing.Service)(
       span: Span,

--- a/opentracing/src/main/scala/zio/telemetry/opentracing/package.scala
+++ b/opentracing/src/main/scala/zio/telemetry/opentracing/package.scala
@@ -68,7 +68,7 @@ package object opentracing {
       OpenTracing.spanFrom(format, carrier, zio, operation, tagError, logError)
 
     def setBaggageItem(key: String, value: String): ZIO[R with OpenTracing, E, A] =
-      zio <* OpenTracing.setBaggageItem(key, value)
+      OpenTracing.setBaggageItem(zio, key, value)
 
     def tag(key: String, value: String): ZIO[R with OpenTracing, E, A] =
       OpenTracing.tag(zio, key, value)

--- a/opentracing/src/main/scala/zio/telemetry/opentracing/package.scala
+++ b/opentracing/src/main/scala/zio/telemetry/opentracing/package.scala
@@ -80,10 +80,10 @@ package object opentracing {
       OpenTracing.tag(zio, key, value)
 
     def log(msg: String): ZIO[R with OpenTracing, E, A] =
-      zio <* OpenTracing.log(msg)
+      OpenTracing.log(zio, msg)
 
     def log(fields: Map[String, _]): ZIO[R with OpenTracing, E, A] =
-      zio <* OpenTracing.log(fields)
+      OpenTracing.log(zio, fields)
 
   }
 }


### PR DESCRIPTION
Resolves #170 

### Summary

- Update service interface to expose only methods accepting zio.
- Rearranged methods alphabetically.
- Scraped some boilerplate (e.g. introduced `ZIO.service` calls).

### Questions

- Can we reduce visibility of `OpenTracing.managed`?
- Can we "hide" `error` and `finish` methods as they seem to be very much internal?
- Should we remove `tag`, `log` and `setBaggageItem` accessors that use `ZIO.unit` as default effect, or add the similar accessors for other methods?