### PR TITLE
Fix "/statuses" tracing in opentracing example

### DIFF
--- a/opentracing-example/src/main/scala/zio/telemetry/opentracing/example/http/StatusesService.scala
+++ b/opentracing-example/src/main/scala/zio/telemetry/opentracing/example/http/StatusesService.scala
@@ -12,7 +12,6 @@ import zio.clock.Clock
 import zio.interop.catz._
 import zio.telemetry.opentracing.OpenTracing
 import zio.UIO
-import zio.ZIO
 import zio.ZLayer
 
 import scala.collection.mutable
@@ -30,7 +29,6 @@ object StatusesService {
       case GET -> Root / "statuses" =>
         val zio =
           for {
-            _       <- ZIO.environment[OpenTracing].root("/statuses")
             _       <- OpenTracing.tag(Tags.SPAN_KIND.getKey, Tags.SPAN_KIND_CLIENT)
             _       <- OpenTracing.tag(Tags.HTTP_METHOD.getKey, GET.name)
             _       <- OpenTracing.setBaggageItem("proxy-baggage-item-key", "proxy-baggage-item-value")
@@ -47,7 +45,9 @@ object StatusesService {
                     }
           } yield res
 
-        zio.provideLayer(service)
+        zio
+          .root("/statuses")
+          .provideLayer(service)
     }
   }
 


### PR DESCRIPTION
Recently I was checking example and I was really interested in this `root` call. I thought that somehow it took the whole for comprehension and set root on it.

Today, I was checking it with Zepkin and I saw that this call had 0ms:
![image](https://user-images.githubusercontent.com/1307829/98282599-c24c3480-1f9e-11eb-9c50-1a599fcfef76.png)

This PR fixes that and now it has correct time
![image](https://user-images.githubusercontent.com/1307829/98282686-e0b23000-1f9e-11eb-9941-5272df0ec19f.png)
