### PR TITLE
Add opencensus to root project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ lazy val root =
   project
     .in(file("."))
     .settings(skip in publish := true)
-    .aggregate(opentracing, opentelemetry, opentracingExample, opentelemetryExample)
+    .aggregate(opentracing, opentelemetry, opencensus, opentracingExample, opentelemetryExample)
 
 lazy val opentracing =
   project


### PR DESCRIPTION
Adding `opencensus` here made it work in `sbt publishLocal`. I do not have permissions to try `sbt ci-release` but :crossed_fingers: it will work for that case too.

See: https://github.com/zio/zio-telemetry/issues/292