### PR TITLE
Add setAttribute for array of values

### DIFF
--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/Tracing.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/Tracing.scala
@@ -2,7 +2,7 @@ package zio.telemetry.opentelemetry
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext
-import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.common.{ AttributeKey, Attributes }
 import io.opentelemetry.api.trace.{ Span, SpanKind, StatusCode, Tracer }
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.propagation.{ TextMapGetter, TextMapPropagator, TextMapSetter }
@@ -10,6 +10,8 @@ import zio.clock.Clock
 import zio.telemetry.opentelemetry.ContextPropagation.{ extractContext, injectContext }
 import zio._
 import io.opentelemetry.api.trace.SpanContext
+
+import scala.jdk.CollectionConverters._
 
 object Tracing {
   trait Service {
@@ -272,6 +274,33 @@ object Tracing {
    */
   def setAttribute(name: String, value: String): URIO[Tracing, Span] =
     getCurrentSpan.map(_.setAttribute(name, value))
+
+  def setAttribute(name: String, values: Seq[String]): URIO[Tracing, Span] = {
+    val v = values.asJava
+    getCurrentSpan.map(_.setAttribute(AttributeKey.stringArrayKey(name), v))
+  }
+
+  def setAttribute(name: String, values: Seq[Boolean])(implicit i1: DummyImplicit): URIO[Tracing, Span] = {
+    val v = values.map(Boolean.box).asJava
+    getCurrentSpan.map(_.setAttribute(AttributeKey.booleanArrayKey(name), v))
+  }
+
+  def setAttribute(name: String, values: Seq[Long])(implicit
+    i1: DummyImplicit,
+    i2: DummyImplicit
+  ): URIO[Tracing, Span] = {
+    val v = values.map(Long.box).asJava
+    getCurrentSpan.map(_.setAttribute(AttributeKey.longArrayKey(name), v))
+  }
+
+  def setAttribute(name: String, values: Seq[Double])(implicit
+    i1: DummyImplicit,
+    i2: DummyImplicit,
+    i3: DummyImplicit
+  ): URIO[Tracing, Span] = {
+    val v = values.map(Double.box).asJava
+    getCurrentSpan.map(_.setAttribute(AttributeKey.doubleArrayKey(name), v))
+  }
 
   /**
    * Gets the current SpanContext

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/TracingSyntax.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/TracingSyntax.scala
@@ -69,5 +69,24 @@ object TracingSyntax {
 
     def setAttribute(name: String, value: String): ZIO[Tracing with R, E, A] =
       effect <* Tracing.setAttribute(name, value)
+
+    def setAttribute(name: String, values: Seq[String]): ZIO[Tracing with R, E, A] =
+      effect <* Tracing.setAttribute(name, values)
+
+    def setAttribute(name: String, values: Seq[Boolean])(implicit i1: DummyImplicit): ZIO[Tracing with R, E, A] =
+      effect <* Tracing.setAttribute(name, values)
+
+    def setAttribute(name: String, values: Seq[Long])(implicit
+      i1: DummyImplicit,
+      i2: DummyImplicit
+    ): ZIO[Tracing with R, E, A] =
+      effect <* Tracing.setAttribute(name, values)(i1, i2)
+
+    def setAttribute(name: String, values: Seq[Double])(implicit
+      i1: DummyImplicit,
+      i2: DummyImplicit,
+      i3: DummyImplicit
+    ): ZIO[Tracing with R, E, A] =
+      effect <* Tracing.setAttribute(name, values)(i1, i2, i3)
   }
 }

--- a/opentelemetry/src/test/scala/zio/telemetry/opentelemetry/TracingTest.scala
+++ b/opentelemetry/src/test/scala/zio/telemetry/opentelemetry/TracingTest.scala
@@ -239,12 +239,22 @@ object TracingTest extends DefaultRunnableSpec {
                        .setAttribute("boolean", true)
                        .setAttribute("int", 1)
                        .setAttribute("string", "foo")
+                       .setAttribute("booleans", Seq(true, false))
+                       .setAttribute("longs", Seq(1L, 2L))
+                       .setAttribute("strings", Seq("foo", "bar"))
                        .span("foo")
             spans <- getFinishedSpans
             tags   = spans.head.getAttributes
           } yield assert(tags.get(AttributeKey.booleanKey("boolean")))(equalTo(Boolean.box(true))) &&
             assert(tags.get(AttributeKey.longKey("int")))(equalTo(Long.box(1))) &&
-            assert(tags.get(AttributeKey.stringKey("string")))(equalTo("foo"))
+            assert(tags.get(AttributeKey.stringKey("string")))(equalTo("foo")) &&
+            assert(tags.get(AttributeKey.booleanArrayKey("booleans")))(
+              equalTo(Seq(Boolean.box(true), Boolean.box(false)).asJava)
+            ) &&
+            assert(tags.get(AttributeKey.longArrayKey("longs")))(
+              equalTo(Seq(Long.box(1L), Long.box(2L)).asJava)
+            ) &&
+            assert(tags.get(AttributeKey.stringArrayKey("strings")))(equalTo(Seq("foo", "bar").asJava))
         },
         testM("logging") {
           val duration = 1000.micros


### PR DESCRIPTION
These `DummyImplicit` are used because of type erasure on those `Seq[_]`. I followed this SO [answer](https://stackoverflow.com/questions/3307427/scala-double-definition-2-methods-have-the-same-type-erasure), not sure if there's a better way.