### PR TITLE
Set attribute with AttributeKey

### DIFF
--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/Tracing.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/Tracing.scala
@@ -2,7 +2,7 @@ package zio.telemetry.opentelemetry
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext
-import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.common.{ AttributeKey, Attributes }
 import io.opentelemetry.api.trace.{ Span, SpanKind, StatusCode, Tracer }
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.propagation.{ TextMapGetter, TextMapPropagator, TextMapSetter }
@@ -272,6 +272,9 @@ object Tracing {
    */
   def setAttribute(name: String, value: String): URIO[Tracing, Span] =
     getCurrentSpan.map(_.setAttribute(name, value))
+
+  def setAttribute[T](key: AttributeKey[T], value: T): URIO[Tracing, Span] =
+    getCurrentSpan.map(_.setAttribute(key, value))
 
   /**
    * Gets the current SpanContext

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/TracingSyntax.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/TracingSyntax.scala
@@ -1,6 +1,6 @@
 package zio.telemetry.opentelemetry
 
-import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.common.{ AttributeKey, Attributes }
 import io.opentelemetry.context.propagation.{ TextMapGetter, TextMapPropagator }
 import io.opentelemetry.api.trace.{ Span, SpanKind, StatusCode }
 import zio.ZIO
@@ -69,5 +69,9 @@ object TracingSyntax {
 
     def setAttribute(name: String, value: String): ZIO[Tracing with R, E, A] =
       effect <* Tracing.setAttribute(name, value)
+
+    def setAttribute[T](key: AttributeKey[T], value: T): ZIO[Tracing with R, E, A] =
+      effect <* Tracing.setAttribute(key, value)
+
   }
 }


### PR DESCRIPTION
This change adds one more variant of `setAttribute` function to let it work nicely with `SemanticAttributes` or other predefined keys.

```scala
import io.opentelemetry.semconv.trace.attributes.SemanticAttributes

ZIO.setAttribute(SemanticAttributes.MESSAGING_SYSTEM, "kafka")
```