### PR TITLE
Set error attribute when encountering an error with a span

### DIFF
--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/Tracing.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/Tracing.scala
@@ -53,7 +53,11 @@ object Tracing {
     toErrorStatus: PartialFunction[E, StatusCode]
   ): UIO[Span] = {
     val errorStatus: StatusCode = cause.failureOption.flatMap(toErrorStatus.lift).getOrElse(StatusCode.UNSET)
-    UIO(span.setStatus(errorStatus, cause.prettyPrint))
+
+    UIO {
+      span.setAttribute("error", true)
+      span.setStatus(errorStatus, cause.prettyPrint)
+    }
   }
 
   /**


### PR DESCRIPTION
👋 we've been using zio-open-telemetry with DataDog for a bit. One weird thing we've been noticing is that our error spans don't show up as having errored in the DataDog UI. 
I think this is because DD expects

```scala
span.setAttribute("error", true)
```

When you encounter an error, which zio-open-telemetry doesn't do currently. Is there interest in adding those to zio-telemetry, probably in here? https://github.com/zio/zio-telemetry/blob/7e6e29c60ad4d9a72c03b175f598fb51f00ea693/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/Tracing.scala#L56
