### PR TITLE
ZIO-2.0.0-RC5

### DIFF
--- a/opentelemetry-example/src/main/scala/zio/telemetry/opentelemetry/example/ProxyServer.scala
+++ b/opentelemetry-example/src/main/scala/zio/telemetry/opentelemetry/example/ProxyServer.scala
@@ -36,7 +36,9 @@ object ProxyServer extends ZIOAppDefault {
   val configLayer = TypesafeConfig.fromResourcePath(descriptor[AppConfig])
 
   val httpBackend: ZLayer[Any, Throwable, SttpBackend[Task, ZioStreams with WebSockets]] =
-    ZLayer.fromAcquireRelease(AsyncHttpClientZioBackend())(_.close().ignore)
+    ZLayer.scoped {
+      ZIO.acquireRelease(AsyncHttpClientZioBackend())(_.close().ignore)
+    }
 
   val sttp: ZLayer[AppConfig, Throwable, Client.Service] = httpBackend >>> Client.live
 

--- a/opentelemetry-example/src/main/scala/zio/telemetry/opentelemetry/example/http/Client.scala
+++ b/opentelemetry-example/src/main/scala/zio/telemetry/opentelemetry/example/http/Client.scala
@@ -19,7 +19,7 @@ object Client {
 
   val up = Status.up("proxy")
 
-  val live: ZLayer[AppConfig with Backend, Throwable, Service] = (for {
+  val live: ZLayer[AppConfig with Backend, Throwable, Service] = ZLayer(for {
     conf    <- ZIO.service[AppConfig]
     backend <- ZIO.service[Backend]
     service  = new Service {
@@ -33,5 +33,5 @@ object Client {
                        Statuses(List(status, up))
                      }
                }
-  } yield service).toLayer
+  } yield service)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,15 +3,15 @@ import sbt._
 object Dependencies {
   object Versions {
     val jaeger        = "1.6.0"
-    val sttp3         = "3.5.1"
+    val sttp3         = "3.5.2"
     val opentracing   = "0.33.0"
     val opentelemetry = "1.11.0"
     val opencensus    = "0.31.0"
     val zipkin        = "2.16.3"
-    val zio           = "2.0.0-RC4"
-    val zioHttp       = "2.0.0-RC6"
-    val zioJson       = "0.3.0-RC6"
-    val zioConfig     = "3.0.0-RC7"
+    val zio           = "2.0.0-RC5"
+    val zioHttp       = "2.0.0-RC6" // FIXME: update to version compatible with ZIO 2.0.0-RC5
+    val zioJson       = "0.3.0-RC7"
+    val zioConfig     = "3.0.0-RC8"
   }
 
   lazy val zio = Seq(


### PR DESCRIPTION
The zio-http dependency has not released yet for RC5 (even though the version bump has been committed) - but this doesn't break example compilation, just runtime.