### PR TITLE
chore(deps): Bump dependency versions, update examples with more moderns versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 **/.DS_Store
 **/metals.sbt
 target
+out/
 .bloop
 .metals
 .idea
@@ -11,4 +12,3 @@ website/build
 website/i18n
 website/static/api
 website/yarn.lock
-

--- a/docs/usecases/opentelemetry_example.md
+++ b/docs/usecases/opentelemetry_example.md
@@ -12,7 +12,7 @@ Firstly, start Jaeger by running the following command:
 docker run --rm -it \
   -p 16686:16686 \
   -p 14250:14250 \
-  jaegertracing/all-in-one:1.16
+  jaegertracing/all-in-one:1.36
 ```
 
 Then start the proxy server

--- a/docs/usecases/opentracing_example.md
+++ b/docs/usecases/opentracing_example.md
@@ -7,8 +7,8 @@ You can find the source code [here](https://github.com/zio/zio-telemetry/tree/ma
 
 Firstly, start [Jaeger](https://www.jaegertracing.io) by running the following command:
 ```bash
-docker run -d --name jaeger \
-  -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 \
+docker run --rm -it \
+  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
   -p 5775:5775/udp \
   -p 6831:6831/udp \
   -p 6832:6832/udp \
@@ -16,7 +16,7 @@ docker run -d --name jaeger \
   -p 16686:16686 \
   -p 14268:14268 \
   -p 9411:9411 \
-  jaegertracing/all-in-one:1.6
+  jaegertracing/all-in-one:1.36
 ``` 
 
 To check if it's running properly visit [Jaeger UI](http://localhost:16686/).

--- a/opentelemetry-example/src/main/scala/zio/telemetry/opentelemetry/example/JaegerTracer.scala
+++ b/opentelemetry-example/src/main/scala/zio/telemetry/opentelemetry/example/JaegerTracer.scala
@@ -1,10 +1,13 @@
 package zio.telemetry.opentelemetry.example
 
+import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter
 import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.sdk.trace.SdkTracerProvider
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes
 import zio._
 import zio.telemetry.opentelemetry.example.config.AppConfig
 
@@ -15,7 +18,14 @@ object JaegerTracer {
       c              <- ZIO.service[AppConfig]
       spanExporter   <- ZIO.attempt(JaegerGrpcSpanExporter.builder().setEndpoint(c.tracer.host).build())
       spanProcessor  <- ZIO.succeed(SimpleSpanProcessor.create(spanExporter))
-      tracerProvider <- ZIO.succeed(SdkTracerProvider.builder().addSpanProcessor(spanProcessor).build())
+      tracerProvider <-
+        ZIO.succeed(
+          SdkTracerProvider
+            .builder()
+            .setResource(Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, "opentelemetry-example")))
+            .addSpanProcessor(spanProcessor)
+            .build()
+        )
       openTelemetry  <- ZIO.succeed(OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build())
       tracer         <- ZIO.succeed(openTelemetry.getTracer("zio.telemetry.opentelemetry.example.JaegerTracer"))
     } yield tracer)

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/Tracing.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/Tracing.scala
@@ -1,16 +1,15 @@
 package zio.telemetry.opentelemetry
 
 import io.opentelemetry.api.baggage.Baggage
+import io.opentelemetry.api.common.{ AttributeKey, Attributes }
+import io.opentelemetry.api.trace._
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.propagation.{ TextMapGetter, TextMapPropagator, TextMapSetter }
+import zio._
+import zio.telemetry.opentelemetry.ContextPropagation.{ extractContext, injectContext }
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext
-import io.opentelemetry.api.common.{ AttributeKey, Attributes }
-import io.opentelemetry.api.trace.{ Span, SpanContext, SpanKind, StatusCode, Tracer }
-import io.opentelemetry.context.Context
-import io.opentelemetry.context.propagation.{ TextMapGetter, TextMapPropagator, TextMapSetter }
-import zio.telemetry.opentelemetry.ContextPropagation.{ extractContext, injectContext }
-import zio._
-
 import scala.jdk.CollectionConverters._
 
 trait Tracing {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,16 +2,23 @@ import sbt._
 
 object Dependencies {
   object Versions {
-    val jaeger        = "1.6.0"
-    val sttp3         = "3.6.2"
-    val opentracing   = "0.33.0"
-    val opentelemetry = "1.11.0"
-    val opencensus    = "0.31.0"
-    val zipkin        = "2.16.3"
-    val zio           = "2.0.0"
-    val zioHttp       = "2.0.0-RC10"
-    val zioJson       = "0.3.0-RC10"
-    val zioConfig     = "3.0.1"
+    val opentracing           = "0.33.0"
+    val opentelemetry         = "1.15.0"
+    val opencensus            = "0.31.1"
+    val scalaCollectionCompat = "2.7.0"
+    val zio                   = "2.0.0"
+  }
+
+  private object ExampleVersions {
+    val cats      = "2.7.0"
+    val grpcNetty = "1.47.0"
+    val jaeger    = "1.8.0"
+    val slf4j     = "1.7.36"
+    val sttp3     = "3.7.0"
+    val zipkin    = "2.16.3"
+    val zioHttp   = "2.0.0-RC10"
+    val zioJson   = "0.3.0-RC10"
+    val zioConfig = "3.0.1"
   }
 
   lazy val zio = Seq(
@@ -24,14 +31,14 @@ object Dependencies {
     "io.opentracing"          % "opentracing-api"         % Versions.opentracing,
     "io.opentracing"          % "opentracing-noop"        % Versions.opentracing,
     "io.opentracing"          % "opentracing-mock"        % Versions.opentracing % Test,
-    "org.scala-lang.modules" %% "scala-collection-compat" % "2.6.0"
+    "org.scala-lang.modules" %% "scala-collection-compat" % Versions.scalaCollectionCompat
   )
 
   lazy val opentelemetry = zio ++ Seq(
     "io.opentelemetry"        % "opentelemetry-api"         % Versions.opentelemetry,
     "io.opentelemetry"        % "opentelemetry-context"     % Versions.opentelemetry,
     "io.opentelemetry"        % "opentelemetry-sdk-testing" % Versions.opentelemetry % Test,
-    "org.scala-lang.modules" %% "scala-collection-compat"   % "2.6.0"
+    "org.scala-lang.modules" %% "scala-collection-compat"   % Versions.scalaCollectionCompat
   )
 
   lazy val opencensus = zio ++ Seq(
@@ -41,27 +48,29 @@ object Dependencies {
   )
 
   lazy val example = Seq(
-    "org.typelevel"                 %% "cats-core"                     % "2.6.1",
-    "io.jaegertracing"               % "jaeger-core"                   % Versions.jaeger,
-    "io.jaegertracing"               % "jaeger-client"                 % Versions.jaeger,
-    "io.jaegertracing"               % "jaeger-zipkin"                 % Versions.jaeger,
-    "com.softwaremill.sttp.client3" %% "async-http-client-backend-zio" % Versions.sttp3,
-    "com.softwaremill.sttp.client3" %% "zio-json"                      % Versions.sttp3,
-    "io.d11"                        %% "zhttp"                         % Versions.zioHttp,
-    "dev.zio"                       %% "zio-json"                      % Versions.zioJson,
-    "dev.zio"                       %% "zio-config"                    % Versions.zioConfig,
-    "dev.zio"                       %% "zio-config-magnolia"           % Versions.zioConfig,
-    "dev.zio"                       %% "zio-config-typesafe"           % Versions.zioConfig
+    "org.typelevel"                 %% "cats-core"                     % ExampleVersions.cats,
+    "io.jaegertracing"               % "jaeger-core"                   % ExampleVersions.jaeger,
+    "io.jaegertracing"               % "jaeger-client"                 % ExampleVersions.jaeger,
+    "io.jaegertracing"               % "jaeger-zipkin"                 % ExampleVersions.jaeger,
+    "com.softwaremill.sttp.client3" %% "async-http-client-backend-zio" % ExampleVersions.sttp3,
+    "com.softwaremill.sttp.client3" %% "zio-json"                      % ExampleVersions.sttp3,
+    "io.d11"                        %% "zhttp"                         % ExampleVersions.zioHttp,
+    "dev.zio"                       %% "zio-json"                      % ExampleVersions.zioJson,
+    "dev.zio"                       %% "zio-config"                    % ExampleVersions.zioConfig,
+    "dev.zio"                       %% "zio-config-magnolia"           % ExampleVersions.zioConfig,
+    "dev.zio"                       %% "zio-config-typesafe"           % ExampleVersions.zioConfig,
+    // runtime to avoid warning in examples
+    "org.slf4j"                      % "slf4j-simple"                  % ExampleVersions.slf4j % Runtime
   )
 
   lazy val opentracingExample = example ++ Seq(
-    "io.zipkin.reporter2" % "zipkin-reporter"       % Versions.zipkin,
-    "io.zipkin.reporter2" % "zipkin-sender-okhttp3" % Versions.zipkin
+    "io.zipkin.reporter2" % "zipkin-reporter"       % ExampleVersions.zipkin,
+    "io.zipkin.reporter2" % "zipkin-sender-okhttp3" % ExampleVersions.zipkin
   )
 
   lazy val opentelemetryExample = example ++ Seq(
     "io.opentelemetry" % "opentelemetry-exporter-jaeger" % Versions.opentelemetry,
     "io.opentelemetry" % "opentelemetry-sdk"             % Versions.opentelemetry,
-    "io.grpc"          % "grpc-netty-shaded"             % "1.40.1"
+    "io.grpc"          % "grpc-netty-shaded"             % ExampleVersions.grpcNetty
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
 addSbtPlugin("com.github.sbt"                    % "sbt-ci-release"   % "1.5.10")
-addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 addSbtPlugin("com.github.sbt"                    % "sbt-unidoc"       % "0.5.0")
-addSbtPlugin("ch.epfl.scala"                     % "sbt-bloop"        % "1.4.12")
-addSbtPlugin("io.github.davidgregory084"         % "sbt-tpolecat"     % "0.1.20")
+addSbtPlugin("ch.epfl.scala"                     % "sbt-bloop"        % "1.5.2")
+addSbtPlugin("io.github.davidgregory084"         % "sbt-tpolecat"     % "0.3.3")
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"     % "2.4.6")
-addSbtPlugin("org.scalameta"                     % "sbt-mdoc"         % "2.3.0")
-addSbtPlugin("org.scoverage"                     % "sbt-scoverage"    % "1.9.3")
+addSbtPlugin("org.scalameta"                     % "sbt-mdoc"         % "2.3.2")
+addSbtPlugin("org.scoverage"                     % "sbt-scoverage"    % "2.0.0")
 
 libraryDependencies += "org.snakeyaml" % "snakeyaml-engine" % "2.3"


### PR DESCRIPTION
Also:

* Bump sttp to 3.7.0 (which is actually required for ZIO 2.0 support - only showed up once I ran proxy server example)
* Add the service.name resource so that the opentelemetry example looks better in jaeger UI
* Moved example versions to own section so it's easier to see what is a core dependency when looking at at it

I know there's sbt 1.7 available now but it changes the cross-compilation handling so perhaps it might need more than a cursory look.