### PR TITLE
Preserve Scopes

### DIFF
--- a/opentelemetry/src/test/scala/zio/telemetry/opentelemetry/TracingTest.scala
+++ b/opentelemetry/src/test/scala/zio/telemetry/opentelemetry/TracingTest.scala
@@ -304,6 +304,15 @@ object TracingTest extends ZIOSpecDefault {
             baggage   <- Tracing.getCurrentBaggage
             entryValue = Option(baggage.getEntryValue("some"))
           } yield assert(entryValue)(equalTo(Some("thing")))
+        },
+        test("resources") {
+          for {
+            ref      <- Ref.make(false)
+            scope    <- Scope.make
+            resource  = ZIO.addFinalizer(ref.set(true))
+            _        <- scope.extend(resource.span("Resource"))
+            released <- ref.get
+          } yield assert(released)(isFalse)
         }
       ).provideCustomLayer(tracingMockLayer)
     )


### PR DESCRIPTION
We need to preserve the scope of resources when we create a span. Since we don't need the scope of the span to be dynamic we should use `acquireReleaseWith` instead of `acquireRelease`.