### PR TITLE
Change github actions according to the new git branches schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
   push:
     branches: 
-      - 'master'
+      - 'series/1.x'
       - 'series/2.x'
   release:
     types:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,7 +2,7 @@ name: Release Drafter
 
 on:
   push:
-    branches: ['master']
+    branches: ['series/2.x']
 
 jobs:
   update_release_draft:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -3,7 +3,7 @@ name: Website
 on:
   push:
     branches: 
-      - 'master'
+      - 'series/1.x'
       - 'series/2.x'
   release:
     types:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,13 +4,13 @@ pull_request_rules:
       - author=scala-steward
     actions:
       assign:
-        users: [runtologist, mijicd]
+        users: [runtologist, mijicd, grouzen]
       label:
         add: [dependency-update]
 
   - name: merge Scala Steward's PRs
     conditions:
-      - base=master
+      - base=series/2.x
       - author=scala-steward  
       - "body~=(labels: library-update, semver-minor)|(labels: library-update, semver-patch)|(labels: sbt-plugin-update, semver-minor)|(labels: sbt-plugin-update, semver-patch)|(labels: scalafix-rule-update)|(labels: test-library-update)" 
       - "status-success=license/cla"


### PR DESCRIPTION
# Why

To take forward migration to ZIO 2, it's been decided to make `series/2.x` branch default and rename `master` to `series/1.x`.

# What

- substitute `master` with `series/1.x`
- make `series/2.x` default for `release-drafter` and `mergify`
- add myself to the list of mergify assignees

Note: We should merge it after renaming the branches.