### PR TITLE
Add convenience TextMap getter/setter for Scala's Map

### DIFF
--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/TextMapAdapter.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/TextMapAdapter.scala
@@ -1,0 +1,22 @@
+package zio.telemetry.opentelemetry
+
+import io.opentelemetry.context.propagation.{ TextMapGetter, TextMapSetter }
+
+import java.lang
+import scala.collection.mutable
+import scala.jdk.CollectionConverters._
+
+object TextMapAdapter
+    extends TextMapGetter[mutable.Map[String, String]]
+    with TextMapSetter[mutable.Map[String, String]] {
+
+  override def keys(carrier: mutable.Map[String, String]): lang.Iterable[String] =
+    carrier.keys.asJava
+
+  override def get(carrier: mutable.Map[String, String], key: String): String =
+    carrier.get(key).orNull
+
+  override def set(carrier: mutable.Map[String, String], key: String, value: String): Unit =
+    carrier.update(key, value)
+
+}


### PR DESCRIPTION
I'm not sure how would maintainers feel about adding this, but I find myself adding this kind of adapter in every project :sweat_smile: 

Usually frameworks/libraries have functions to add outbound headers from a map or to convert inbound headers to a map. So it seems that having this adapter readily available would be quite convenient.

But if this doesn't make much sense, please do feel free to close this PR. No hard feelings :sweat_smile: 