### PR TITLE
Propagate OTEL context between ZIO and non-ZIO code

### DIFF
--- a/docs/overview/opentelemetry.md
+++ b/docs/overview/opentelemetry.md
@@ -87,3 +87,36 @@ val injectExtract =
     .spanFrom(propagator, carrier, getter, "baz")
     .span("bar")
 ```
+
+### [Experimental] Usage with OpenTelemetry automatic instrumentation
+
+OpenTelemetry provides
+a [JVM agent for automatic instrumentation](https://opentelemetry.io/docs/instrumentation/java/automatic/) which
+supports
+many [popular Java libraries](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/supported-libraries.md)
+.
+
+This automatic instrumentation relies on the default OpenTelemetry context storage which is based on `ThreadLocal`. So
+it doesn't work with ZIO out of the box.
+
+`zio-opentelemetry` provides an experimental version of `Tracing` which bidirectionally propagates tracing context
+between ZIO and non-ZIO code, enabling interoperability with _most_ libraries that use the default OpenTelemetry context
+storage.
+
+To enable this experimental propagation, you will need to create `Tracing` using `Tracing.propagating` constructor (
+instead of `Tracing.live`).
+
+Please note that whether context propagation will work correctly depends on which specific ZIO wrappers around non-ZIO
+libraries you are using. So please, test your specific setup.
+
+It was reported that it works with:
+
+* `zhttp`
+* `sttp` with Java 11+ HTTP client backend
+* `zio-kafka`
+* `doobie`
+* `redis4cats`
+
+It was reported that it does not work with:
+
+* `sttp` with `armeria` backend

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/ContextStorage.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/ContextStorage.scala
@@ -1,0 +1,62 @@
+package zio.telemetry.opentelemetry
+
+import io.opentelemetry.context.Context
+import zio.{ FiberRef, UIO, ZIO }
+
+private[opentelemetry] trait ContextStorage {
+
+  def get: UIO[Context]
+
+  def set(context: Context): UIO[Unit]
+
+  def getAndSet(context: Context): UIO[Context]
+
+  def updateAndGet(f: Context => Context): UIO[Context]
+
+  def locally[R, E, A](context: Context)(effect: ZIO[R, E, A]): ZIO[R, E, A]
+
+}
+
+private[opentelemetry] object ContextStorage {
+
+  /**
+   * Use provided [[FiberRef]] as a [[ContextStorage]].
+   */
+  def fiberRef(ref: FiberRef[Context]): ContextStorage = new ContextStorage {
+    override def get: UIO[Context]                                                      = ref.get
+    override def set(context: Context): UIO[Unit]                                       = ref.set(context)
+    override def getAndSet(context: Context): UIO[Context]                              = ref.getAndSet(context)
+    override def updateAndGet(f: Context => Context): UIO[Context]                      = ref.updateAndGet(f)
+    override def locally[R, E, A](context: Context)(effect: ZIO[R, E, A]): ZIO[R, E, A] = ref.locally(context)(effect)
+  }
+
+  /**
+   * Use OpenTelemetry's default context storage which is backed by a [[ThreadLocal]]. This makes sense only if
+   * [[PropagatingSupervisor]] is used.
+   */
+  def threadLocal: ContextStorage = new ContextStorage {
+
+    override def get: UIO[Context] = ZIO.succeed(Context.current())
+
+    override def set(context: Context): UIO[Unit] = ZIO.succeed(context.makeCurrent()).unit
+
+    override def getAndSet(context: Context): UIO[Context] =
+      ZIO.succeed {
+        val old = Context.current()
+        val _   = context.makeCurrent()
+        old
+      }.uninterruptible
+
+    override def updateAndGet(f: Context => Context): UIO[Context] =
+      ZIO.succeed {
+        val updated = f(Context.current())
+        val _       = updated.makeCurrent()
+        updated
+      }.uninterruptible
+
+    override def locally[R, E, A](context: Context)(effect: ZIO[R, E, A]): ZIO[R, E, A] =
+      ZIO.acquireReleaseWith(get <* set(context))(set)(_ => effect)
+
+  }
+
+}

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/PropagatingSupervisor.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/PropagatingSupervisor.scala
@@ -1,0 +1,45 @@
+package zio.telemetry.opentelemetry
+
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.context.Context
+import zio._
+
+import java.util.concurrent.ConcurrentHashMap
+import scala.annotation.nowarn
+
+@nowarn("msg=discarded non-Unit value")
+final class PropagatingSupervisor extends Supervisor[Unit] {
+
+  private val storage = new ConcurrentHashMap[FiberId, Span]()
+
+  override def value(implicit trace: Trace): UIO[Unit] = ZIO.unit
+
+  override def onStart[R, E, A](
+    environment: ZEnvironment[R],
+    effect: ZIO[R, E, A],
+    parent: Option[Fiber.Runtime[Any, Any]],
+    fiber: Fiber.Runtime[E, A]
+  )(implicit unsafe: Unsafe): Unit = {
+    val span = Span.current()
+    if (span != null) storage.put(fiber.id, span)
+    else storage.put(fiber.id, Span.fromContext(Context.root()))
+  }
+
+  override def onEnd[R, E, A](value: Exit[E, A], fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = {
+    storage.remove(fiber.id)
+    Context.root().makeCurrent()
+  }
+
+  override def onSuspend[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = {
+    val span = Span.current()
+    if (span != null) storage.put(fiber.id, span)
+    else storage.put(fiber.id, Span.fromContext(Context.root()))
+    Context.root().makeCurrent()
+  }
+
+  override def onResume[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = {
+    val span = storage.get(fiber.id)
+    if (span != null) span.makeCurrent()
+  }
+
+}


### PR DESCRIPTION
### Motivation

At the moment OTEL context is not propagated between ZIO and non-ZIO code. Of course, there are functions from `scopedEffect` family provided by `Tracing`, but they expect an unsafe size-effecting code as their argument.

In case if you need to propagate context into libraries that wrap non-ZIO code into ZIO, but don't use tracing - there is no guarantee that underlying non-ZIO code will have access to the correct context.

And in cases when non-ZIO code invokes ZIO code (for example in `zhttp`, which starts fibers from Netty code) context is not (correctly) propagated as well.

This change makes it possible to use automatic instrumentation provided by [OpenTelemetry JVM agent](https://opentelemetry.io/docs/instrumentation/java/automatic/).

Related: https://github.com/zio/zio-telemetry/issues/561

### How this works

This solution uses a special ZIO supervisor that takes a snapshot of the current OpenTelemetry context before a new ZIO fiber is started and uses it as a parent context in the scope of that fiber.

Each time a fiber is suspended, supervisor takes a fresh snapshot of the current context and then restores the root context. When fiber is resumed, it restores the last context snapshot for that fiber.

When fiber is completed, supervisor restores the root context.

Probably, this is not the most correct or efficient implementation, but it does seem to work.

There is an end-to-end setup that uses this kind of supervisor here: https://github.com/dmytr/zio-otel-instrumentation.
