### PR TITLE
Add additional checks for docs to check command alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ ZIO Telemetry is a purely functional client which helps up propagate context bet
 In order to use this library, we need to add the following line in our `build.sbt` file if we want to use [OpenTelemetry](https://opentelemetry.io/) client:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-telemetry" % "3.0.0-RC2"
+libraryDependencies += "dev.zio" %% "zio-telemetry" % "3.0.0-RC3"
 ```
 
 And for using [OpenTracing](https://opentracing.io/) client we should add the following line in our `build.sbt` file:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-opentracing" % "3.0.0-RC2"
+libraryDependencies += "dev.zio" %% "zio-opentracing" % "3.0.0-RC3"
 ```
 
 ## Example

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,10 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 Global / testFrameworks       := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
 
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
-addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
+addCommandAlias(
+  "check",
+  "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck docs/checkReadme docs/checkGithubWorkflow"
+)
 addCommandAlias("compileExamples", "opentracingExample/compile;opentelemetryExample/compile")
 
 lazy val root =


### PR DESCRIPTION
I think it is a good idea to add `docs/checkReadme` and `docs/checkGithubWorkflow` to the `check` command alias for better ergonomics since new contributors are experiencing issues with the current CI flow as it asks them to run `docs/generateReadme` event after `check` succeed.