### PR TITLE
Opentelemetry zio integrate log annotations to baggage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ ZIO Telemetry is a purely functional client which helps up propagate context bet
 In order to use this library, we need to add the following line in our `build.sbt` file if we want to use [OpenTelemetry](https://opentelemetry.io/) client:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-telemetry" % "3.0.0-RC3"
+libraryDependencies += "dev.zio" %% "zio-telemetry" % "3.0.0-RC4"
 ```
 
 And for using [OpenTracing](https://opentracing.io/) client we should add the following line in our `build.sbt` file:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-opentracing" % "3.0.0-RC3"
+libraryDependencies += "dev.zio" %% "zio-opentracing" % "3.0.0-RC4"
 ```
 
 ## Example

--- a/opentelemetry-example/src/main/scala/zio/telemetry/opentelemetry/example/BackendApp.scala
+++ b/opentelemetry-example/src/main/scala/zio/telemetry/opentelemetry/example/BackendApp.scala
@@ -21,7 +21,7 @@ object BackendApp extends ZIOAppDefault {
         BackendHttpServer.live,
         BackendHttpApp.live,
         Tracing.live,
-        Baggage.live,
+        Baggage.live(),
         ContextStorage.fiberRef,
         JaegerTracer.live
       )

--- a/opentelemetry-example/src/main/scala/zio/telemetry/opentelemetry/example/ProxyApp.scala
+++ b/opentelemetry-example/src/main/scala/zio/telemetry/opentelemetry/example/ProxyApp.scala
@@ -29,7 +29,7 @@ object ProxyApp extends ZIOAppDefault {
         ProxyHttpServer.live,
         ProxyHttpApp.live,
         Tracing.live,
-        Baggage.live,
+        Baggage.live(),
         ContextStorage.fiberRef,
         JaegerTracer.live
       )


### PR DESCRIPTION
This PR solves one of the subtasks of https://github.com/zio/zio-telemetry/issues/558. 

The solution is to propagate ZIO log annotations as OTEL Baggage values automatically. For this, the end user should use  `Baggage.logAnnotated` or `Baggage.live(logAnnotated = true)` layer constructor.