### PR TITLE
Log a Throwable rather than a Cause in OpenTracing's logError

### DIFF
--- a/opentracing/src/main/scala/zio/telemetry/opentracing/OpenTracing.scala
+++ b/opentracing/src/main/scala/zio/telemetry/opentracing/OpenTracing.scala
@@ -126,7 +126,9 @@ object OpenTracing {
         )(implicit trace: Trace): UIO[Unit] =
           for {
             _ <- ZIO.succeed(span.setTag("error", true)).when(tagError)
-            _ <- ZIO.succeed(span.log(Map("error.object" -> cause, "stack" -> cause.prettyPrint).asJava)).when(logError)
+            _ <- ZIO
+                   .succeed(span.log(Map("error.object" -> FiberFailure(cause), "stack" -> cause.prettyPrint).asJava))
+                   .when(logError)
           } yield ()
 
         override def finish(span: Span)(implicit trace: Trace): UIO[Unit] =


### PR DESCRIPTION
Some tracer libraries such as dd-trace (Datadog) have special logic when the error type is a `Throwable`, but are not able to do anything with a `Cause`.

Before I would see this with no details about the error:
<img width="472" alt="Screen Shot 2023-11-24 at 10 20 33 AM" src="https://github.com/zio/zio-telemetry/assets/7413894/48090b19-ee29-4394-8b64-81097b9caa2f">

After that change, I would get the error details with the full stack trace:
<img width="1069" alt="Screen Shot 2023-11-24 at 10 21 29 AM" src="https://github.com/zio/zio-telemetry/assets/7413894/c466480c-4695-4e49-84ed-ec7b699c4287">

The [spec](https://github.com/opentracing/specification/blob/master/semantic_conventions.md) says "For languages that support such a thing (e.g., Java, Python), the actual Throwable/Exception/Error object instance itself." so I think it makes sense not just for Datadog.

Relevant logic in dd-trace: https://github.com/DataDog/dd-trace-java/blob/a760c687369c971fa38d95c103883ed672394e6c/dd-trace-ot/src/main/java/datadog/opentracing/DefaultLogHandler.java#L45