### PR TITLE
Integration with ZIO metrics

### DIFF
--- a/docs/opentelemetry-example.md
+++ b/docs/opentelemetry-example.md
@@ -9,7 +9,9 @@ For an explanation in more detail, check the [OpenTracing Example](opentracing-e
 
 We're going to show an example of how to pass contextual information using [Baggage](https://opentelemetry.io/docs/concepts/signals/baggage/) and collect traces, metrics, and logs.
 
----
+# Run
+
+## Print OTEL signals to console
 
 By default the example code uses [OTLP Logging Exporters](https://github.com/open-telemetry/opentelemetry-java/tree/main/exporters/logging-otlp) to print all signals to stdout in OTLP JSON encoding. This means that you can run the application immediately and observe the results.
 
@@ -28,11 +30,11 @@ Now perform the following request to see the results immediately:
 curl -X GET http://localhost:8080/statuses
 ```
 
----
+## Publish OTEL signals to other observability platforms
 
 In case you want to try different observability platforms such as [Jaeger](https://www.jaegertracing.io/), [Fluentbit](https://fluentbit.io/), [Seq](https://datalust.co/seq), [DataDog](https://www.datadoghq.com/), [Honeycomb](https://www.honeycomb.io/) or others, please change the [OtelSdk.scala](https://github.com/zio/zio-telemetry/blob/series/2.x/opentelemetry-example/src/main/scala/zio/telemetry/opentelemetry/example/otel/OtelSdk.scala) file by choosing from the available tracer, meter, and logger providers or by implementing your own. 
 
---- 
+## Publish OTEL signals to Jaeger and Seq
 
 We chose [Jaeger](https://www.jaegertracing.io/) for distributed traces and [Seq](https://datalust.co/seq) to store logs to demonstrate how the library works with available open-source observability platforms.
 
@@ -60,4 +62,4 @@ docker run \
   datalust/seq
 ```
 
-Run the application and fire a curl request as shown above, and then head over to [Jaeger UI](http://localhost:16686/) and [Seq UI](http://localhost:80/) to see the result.
+Run the application and fire a curl request as shown above. Head over to [Jaeger UI](http://localhost:16686/) and [Seq UI](http://localhost:80/) to see the result.

--- a/docs/opentelemetry.md
+++ b/docs/opentelemetry.md
@@ -145,12 +145,12 @@ To send [Metric signals](https://opentelemetry.io/docs/concepts/signals/metrics/
 As a rule of thumb, observable instruments must be initialized on an application startup. They are scoped, so you should not be worried about shutting them down manually.
 
 ```scala
-//> using scala "2.13.12"
-//> using dep dev.zio::zio:2.0.20
-//> using dep dev.zio::zio-opentelemetry:3.0.0-RC20
-//> using dep io.opentelemetry:opentelemetry-sdk:1.33.0
-//> using dep io.opentelemetry:opentelemetry-sdk-trace:1.33.0
-//> using dep io.opentelemetry:opentelemetry-exporter-logging-otlp:1.33.0
+//> using scala "2.13.13"
+//> using dep dev.zio::zio:2.0.21
+//> using dep dev.zio::zio-opentelemetry:3.0.0-RC22
+//> using dep io.opentelemetry:opentelemetry-sdk:1.36.0
+//> using dep io.opentelemetry:opentelemetry-sdk-trace:1.36.0
+//> using dep io.opentelemetry:opentelemetry-exporter-logging-otlp:1.36.0
 //> using dep io.opentelemetry.semconv:opentelemetry-semconv:1.22.0-alpha
 
 import io.opentelemetry.sdk.trace.SdkTracerProvider
@@ -278,7 +278,7 @@ object MetricsApp extends ZIOAppDefault {
       .provide(
         otelSdkLayer,
         ContextStorage.fiberRef,
-        OpenTelemetry.meter(instrumentationScopeName),
+        OpenTelemetry.metrics(instrumentationScopeName),
         OpenTelemetry.tracing(instrumentationScopeName),
         tickCounterLayer,
         tickRefLayer

--- a/docs/opentelemetry.md
+++ b/docs/opentelemetry.md
@@ -12,7 +12,7 @@ Some of the key features:
 - **ZIO native** - Pleasant API that leverages native ZIO features, such as [Resource Management](https://zio.dev/reference/resource/), [Depenency Injection](https://zio.dev/reference/di/), [Streaming](https://zio.dev/reference/stream/), [Logging](https://zio.dev/reference/observability/logging), [Metrics](https://zio.dev/reference/observability/metrics/), and [ZIO Aspect](https://zio.dev/reference/core/zio/#zio-aspect)
 - **OpenTelemetry Java SDK and ZIO Runtime interoperability** - Protecting users from directly engaging in OTEL context manipulations, offering a straightforward and clear interface for instrumenting spans, metrics, logs, and baggage. In this scenario, the ZIO effect serves as the span's scope.
 - **Seamless signals correlation** -  Automatically correlates spans, metrics, and logs with a surrounding span.
-- **Integration with ZIO capabilities** - Propagation of log annotations, metrics, and other data from the ZIO runtime as OTEL attributes and metrics.
+- **Integration with ZIO capabilities** - Propagation of log annotations, metrics, and other data from the ZIO runtime as OTEL attributes and metric signals.
 
 ## Installation
 
@@ -35,6 +35,51 @@ For the complete list of available Java artifacts, please consult the informatio
 ## Usage
 
 All examples below can be run using amazing [Scala CLI](https://scala-cli.virtuslab.org/). You can find their full copies in the `scala-cli/opentelemetry/` directory. To run, type `scala-cli <AppName>.scala` while in the directory where the file is located.
+
+### Setup
+
+The `zio.telemetry.opentelemetry.OpenTelemetry` (aka entry point) offers a comprehensive set of layers for instrumenting your ZIO application. 
+
+First of all, you need to provide an instance of `io.opentelemetry.api.Opentelemetry`.
+In case you don't need an automatic instrumentation, you can use `OpenTelemetry.custom` layer. It receives a scoped ZIO effect indicating that the provided instance will be closed when the application is shut down. Here is an example:
+
+```scala
+import zio._
+import zio.telemetry.opentelemetry.OpenTelemetry
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.api
+
+def custom(resourceName: String): TaskLayer[api.OpenTelemetry] =
+  OpenTelemetry.custom(
+    for {
+      tracerProvider <- TracerProvider.stdout(resourceName)
+      meterProvider  <- MeterProvider.stdout(resourceName)
+      loggerProvider <- LoggerProvider.stdout(resourceName)
+      openTelemetry  <- ZIO.fromAutoCloseable(
+                          ZIO.succeed(
+                            OpenTelemetrySdk
+                              .builder()
+                              .setTracerProvider(tracerProvider)
+                              .setMeterProvider(meterProvider)
+                              .setLoggerProvider(loggerProvider)
+                              .build
+                          )
+                        )
+    } yield openTelemetry
+  )
+```
+
+The library depends only on `opentelemetry-api` which means you have to manage an initialization of providers and depenendencies for `opentelemetry-sdk`, and `opentelemetry-exporter-*` inside your application.
+
+For more details, please have a look at the source code of the [example application](https://github.com/zio/zio-telemetry/tree/series/2.x/opentelemetry-example/src/main/scala/zio/telemetry/opentelemetry/example).
+
+#### Usage with OpenTelemetry automatic instrumentation
+
+OpenTelemetry provides a [JVM agent for automatic instrumentation](https://opentelemetry.io/docs/instrumentation/java/automatic/) which supports many [popular Java libraries](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/supported-libraries.md).
+Since [version 1.25.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.25.0) OpenTelemetry JVM agent supports ZIO.
+
+To enable interoperability between automatic instrumentation and `zio-opentelemetry`, `Tracing` has to be created
+using `ContextStorage` backed by OpenTelemetry's native `Context` and `Tracer` provided by globally registered `TracerProvider`. It means that instead of `ContextStorage.fiberRef` and `OpenTelemetry.custom` you have to provide `ContextStorage.native` and `OpenTelemetry.global` layers.
 
 ### Tracing
 
@@ -286,6 +331,10 @@ object MetricsApp extends ZIOAppDefault {
 
 }
 ```
+
+#### Integration with ZIO metrics
+
+To enable seamless integration with [ZIO metrics](https://zio.dev/reference/observability/metrics/), use the `OpenTelemetry.zioMetrics` layer. If you also need to publish JVM metrics, be sure to include `DefaultJvmMetrics.live.unit`.
 
 ### Logging
 
@@ -568,11 +617,3 @@ object PropagatingApp extends ZIOAppDefault {
 
 }
 ```
-
-### Usage with OpenTelemetry automatic instrumentation
-
-OpenTelemetry provides a [JVM agent for automatic instrumentation](https://opentelemetry.io/docs/instrumentation/java/automatic/) which supports many [popular Java libraries](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/supported-libraries.md).
-Since [version 1.25.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.25.0) OpenTelemetry JVM agent supports ZIO.
-
-To enable interoperability between automatic instrumentation and `zio-opentelemetry`, `Tracing` has to be created
-using `ContextStorage` backed by OpenTelemetry's native `Context` and `Tracer` provided by globally registered `TracerProvider`. It means that instead of `ContextStorage.fiberRef` and `OpenTelemetry.custom` you have to provide `ContextStorage.native` and `OpenTelemetry.global` layers.

--- a/opentelemetry-example/src/main/scala/zio/telemetry/opentelemetry/example/BackendApp.scala
+++ b/opentelemetry-example/src/main/scala/zio/telemetry/opentelemetry/example/BackendApp.scala
@@ -9,6 +9,7 @@ import zio.telemetry.opentelemetry.context.ContextStorage
 import zio.telemetry.opentelemetry.OpenTelemetry
 import zio.telemetry.opentelemetry.example.otel.OtelSdk
 import zio.telemetry.opentelemetry.metrics.Meter
+import zio.metrics.jvm.DefaultJvmMetrics
 
 object BackendApp extends ZIOAppDefault {
 
@@ -51,12 +52,14 @@ object BackendApp extends ZIOAppDefault {
         BackendHttpApp.live,
         OtelSdk.custom(resourceName),
         OpenTelemetry.tracing(instrumentationScopeName),
-        OpenTelemetry.meter(instrumentationScopeName),
+        OpenTelemetry.metrics(instrumentationScopeName),
         OpenTelemetry.logging(instrumentationScopeName),
         OpenTelemetry.baggage(),
+        OpenTelemetry.zioMetrics,
+        DefaultJvmMetrics.live.unit,
         globalTickCounterLayer,
         tickRefLayer,
-        ContextStorage.fiberRef
+        ContextStorage.fiberRef,
       )
 
 }

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/OpenTelemetry.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/OpenTelemetry.scala
@@ -2,16 +2,13 @@ package zio.telemetry.opentelemetry
 
 import io.opentelemetry.api
 import zio._
+import zio.metrics.{MetricClient, MetricListener}
 import zio.telemetry.opentelemetry.baggage.Baggage
 import zio.telemetry.opentelemetry.context.ContextStorage
 import zio.telemetry.opentelemetry.logging.Logging
 import zio.telemetry.opentelemetry.metrics.Meter
+import zio.telemetry.opentelemetry.metrics.internal.{Instrument, InstrumentRegistry, OtelMetricListener}
 import zio.telemetry.opentelemetry.tracing.Tracing
-import zio.telemetry.opentelemetry.metrics.internal.Instrument
-import zio.metrics.MetricListener
-import zio.metrics.MetricClient
-import zio.telemetry.opentelemetry.metrics.internal.InstrumentRegistry
-import zio.telemetry.opentelemetry.metrics.internal.OtelMetricListener
 
 /**
  * The entrypoint to telemetry functionality for tracing, metrics, logging and baggage.

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/OpenTelemetry.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/OpenTelemetry.scala
@@ -7,6 +7,11 @@ import zio.telemetry.opentelemetry.context.ContextStorage
 import zio.telemetry.opentelemetry.logging.Logging
 import zio.telemetry.opentelemetry.metrics.Meter
 import zio.telemetry.opentelemetry.tracing.Tracing
+import zio.telemetry.opentelemetry.metrics.internal.Instrument
+import zio.metrics.MetricListener
+import zio.metrics.MetricClient
+import zio.telemetry.opentelemetry.metrics.internal.InstrumentRegistry
+import zio.telemetry.opentelemetry.metrics.internal.OtelMetricListener
 
 /**
  * The entrypoint to telemetry functionality for tracing, metrics, logging and baggage.
@@ -82,12 +87,12 @@ object OpenTelemetry {
    * @param schemaUrl
    *   schema URL
    */
-  def meter(
+  def metrics(
     instrumentationScopeName: String,
     instrumentationVersion: Option[String] = None,
     schemaUrl: Option[String] = None
-  ): URLayer[api.OpenTelemetry with ContextStorage, Meter] = {
-    val meterLayer = ZLayer(
+  ): URLayer[api.OpenTelemetry with ContextStorage, Meter with Instrument.Builder] = {
+    val meterLayer   = ZLayer(
       ZIO.serviceWith[api.OpenTelemetry] { openTelemetry =>
         val builder = openTelemetry.meterBuilder(instrumentationScopeName)
 
@@ -97,8 +102,32 @@ object OpenTelemetry {
         builder.build()
       }
     )
+    val builderLayer = meterLayer >>> Instrument.Builder.live
 
-    meterLayer >>> Meter.live
+    builderLayer >+> (builderLayer >>> Meter.live)
+  }
+
+  /**
+   * Use when you want to allow a seamless integration with ZIO runtime and JVM metrics
+   *
+   * By default this layer enables the propagation of ZIO runtime metrics only. For JVM metrics you need to provide
+   * `DefaultJvmMetrics.live.unit`.
+   */
+  def zioMetrics: URLayer[Instrument.Builder, Unit] = {
+    val metricListenerLifecycleLayer = ZLayer.scoped {
+      ZIO.serviceWithZIO[MetricListener] { metricListener =>
+        Unsafe.unsafe { implicit unsafe =>
+          ZIO.acquireRelease(
+            ZIO.succeed(MetricClient.addListener(metricListener))
+          )(_ => ZIO.succeed(MetricClient.removeListener(metricListener)))
+        }
+      }
+    }
+
+    Runtime.enableRuntimeMetrics >>>
+      InstrumentRegistry.concurrent >>>
+      OtelMetricListener.zioMetrics >>>
+      metricListenerLifecycleLayer
   }
 
   /**

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/baggage/Baggage.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/baggage/Baggage.scala
@@ -199,7 +199,4 @@ object Baggage {
       }
     }
 
-  def logAnnotated: URLayer[ContextStorage, Baggage] =
-    live(logAnnotated = true)
-
 }

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/context/ContextStorage.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/context/ContextStorage.scala
@@ -92,8 +92,8 @@ object ContextStorage {
     ZLayer.scoped(
       FiberRef
         .make[Context](Context.root())
-        .flatMap { ref =>
-          ZIO.succeed(new ZIOFiberRef(ref))
+        .map { ref =>
+          new ZIOFiberRef(ref)
         }
     )
 

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/Counter.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/Counter.scala
@@ -2,10 +2,10 @@ package zio.telemetry.opentelemetry.metrics
 
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.metrics.LongCounter
+import io.opentelemetry.context.Context
 import zio._
 import zio.telemetry.opentelemetry.context.ContextStorage
 import zio.telemetry.opentelemetry.metrics.internal.Instrument
-import io.opentelemetry.context.Context
 
 /**
  * A Counter instrument that records values of type `A`

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/Counter.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/Counter.scala
@@ -4,6 +4,8 @@ import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.metrics.LongCounter
 import zio._
 import zio.telemetry.opentelemetry.context.ContextStorage
+import zio.telemetry.opentelemetry.metrics.internal.Instrument
+import io.opentelemetry.context.Context
 
 /**
  * A Counter instrument that records values of type `A`
@@ -11,7 +13,7 @@ import zio.telemetry.opentelemetry.context.ContextStorage
  * @tparam A
  *   according to the specification, it can be either [[scala.Long]] or [[scala.Double]] type
  */
-trait Counter[-A] {
+trait Counter[-A] extends Instrument[A] {
 
   /**
    * Records a value.
@@ -43,8 +45,11 @@ object Counter {
   private[metrics] def long(counter: LongCounter, ctxStorage: ContextStorage): Counter[Long] =
     new Counter[Long] {
 
+      override def record0(value: Long, attributes: Attributes = Attributes.empty, context: Context): Unit =
+        counter.add(value, attributes, context)
+
       override def add(value: Long, attributes: Attributes = Attributes.empty)(implicit trace: Trace): UIO[Unit] =
-        ctxStorage.get.map(counter.add(value, attributes, _))
+        ctxStorage.get.map(record0(value, attributes, _))
 
       override def inc(attributes: Attributes = Attributes.empty)(implicit trace: Trace): UIO[Unit] =
         add(1L, attributes)

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/Histogram.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/Histogram.scala
@@ -4,6 +4,8 @@ import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.metrics.DoubleHistogram
 import zio._
 import zio.telemetry.opentelemetry.context.ContextStorage
+import zio.telemetry.opentelemetry.metrics.internal.Instrument
+import io.opentelemetry.context.Context
 
 /**
  * A Histogram instrument that records values of type `A`
@@ -11,7 +13,7 @@ import zio.telemetry.opentelemetry.context.ContextStorage
  * @tparam A
  *   according to the specification, it can be either [[scala.Long]] or [[scala.Double]] type
  */
-trait Histogram[-A] {
+trait Histogram[-A] extends Instrument[A] {
 
   /**
    * Records a value.
@@ -33,8 +35,11 @@ object Histogram {
   private[metrics] def double(histogram: DoubleHistogram, ctxStorage: ContextStorage): Histogram[Double] =
     new Histogram[Double] {
 
+      override def record0(value: Double, attributes: Attributes = Attributes.empty, context: Context): Unit =
+        histogram.record(value, attributes, context)
+
       override def record(value: Double, attributes: Attributes = Attributes.empty)(implicit trace: Trace): UIO[Unit] =
-        ctxStorage.get.map(histogram.record(value, attributes, _))
+        ctxStorage.get.map(record0(value, attributes, _))
 
     }
 

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/Histogram.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/Histogram.scala
@@ -2,10 +2,10 @@ package zio.telemetry.opentelemetry.metrics
 
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.metrics.DoubleHistogram
+import io.opentelemetry.context.Context
 import zio._
 import zio.telemetry.opentelemetry.context.ContextStorage
 import zio.telemetry.opentelemetry.metrics.internal.Instrument
-import io.opentelemetry.context.Context
 
 /**
  * A Histogram instrument that records values of type `A`

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/ObservableMeasurement.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/ObservableMeasurement.scala
@@ -12,6 +12,8 @@ import zio._
  */
 trait ObservableMeasurement[-A] {
 
+  def record0(value: A, attributes: Attributes = Attributes.empty): Unit
+
   /**
    * Records a measurement.
    *
@@ -20,7 +22,8 @@ trait ObservableMeasurement[-A] {
    * @param attributes
    *   set of attributes to associate with the value
    */
-  def record(value: A, attributes: Attributes = Attributes.empty)(implicit trace: Trace): Task[Unit]
+  def record(value: A, attributes: Attributes = Attributes.empty)(implicit trace: Trace): Task[Unit] =
+    ZIO.succeed(record0(value, attributes))
 
 }
 
@@ -29,16 +32,16 @@ object ObservableMeasurement {
   private[metrics] def long(om: api.metrics.ObservableLongMeasurement): ObservableMeasurement[Long] =
     new ObservableMeasurement[Long] {
 
-      override def record(value: Long, attributes: Attributes = Attributes.empty)(implicit trace: Trace): Task[Unit] =
-        ZIO.succeed(om.record(value, attributes))
+      override def record0(value: Long, attributes: Attributes): Unit =
+        om.record(value, attributes)
 
     }
 
   private[metrics] def double(om: api.metrics.ObservableDoubleMeasurement): ObservableMeasurement[Double] =
     new ObservableMeasurement[Double] {
 
-      override def record(value: Double, attributes: Attributes = Attributes.empty)(implicit trace: Trace): Task[Unit] =
-        ZIO.succeed(om.record(value, attributes))
+      override def record0(value: Double, attributes: Attributes): Unit =
+        om.record(value, attributes)
 
     }
 

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/UpDownCounter.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/UpDownCounter.scala
@@ -4,6 +4,8 @@ import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.metrics.LongUpDownCounter
 import zio._
 import zio.telemetry.opentelemetry.context.ContextStorage
+import zio.telemetry.opentelemetry.metrics.internal.Instrument
+import io.opentelemetry.context.Context
 
 /**
  * A UpDownCounter instrument that records values of type `A`
@@ -11,7 +13,7 @@ import zio.telemetry.opentelemetry.context.ContextStorage
  * @tparam A
  *   according to the specification, it can be either [[scala.Long]] or [[scala.Double]] type
  */
-trait UpDownCounter[-A] {
+trait UpDownCounter[-A] extends Instrument[A] {
 
   /**
    * Records a value.
@@ -55,8 +57,11 @@ object UpDownCounter {
   private[metrics] def long(counter: LongUpDownCounter, ctxStorage: ContextStorage): UpDownCounter[Long] =
     new UpDownCounter[Long] {
 
+      override def record0(value: Long, attributes: Attributes = Attributes.empty, context: Context): Unit =
+        counter.add(value, attributes, context)
+
       override def add(value: Long, attributes: Attributes = Attributes.empty)(implicit trace: Trace): UIO[Unit] =
-        ctxStorage.get.map(counter.add(value, attributes, _))
+        ctxStorage.get.map(record0(value, attributes, _))
 
       override def inc(attributes: Attributes = Attributes.empty)(implicit trace: Trace): UIO[Unit] =
         add(1L, attributes)

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/UpDownCounter.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/UpDownCounter.scala
@@ -2,10 +2,10 @@ package zio.telemetry.opentelemetry.metrics
 
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.metrics.LongUpDownCounter
+import io.opentelemetry.context.Context
 import zio._
 import zio.telemetry.opentelemetry.context.ContextStorage
 import zio.telemetry.opentelemetry.metrics.internal.Instrument
-import io.opentelemetry.context.Context
 
 /**
  * A UpDownCounter instrument that records values of type `A`

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/AtomicDouble.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/AtomicDouble.scala
@@ -1,0 +1,31 @@
+package zio.telemetry.opentelemetry.metrics.internal
+
+import java.util.concurrent.atomic.AtomicLong
+
+final class AtomicDouble(val ref: AtomicLong) extends AnyVal {
+
+  def get(): Double =
+    java.lang.Double.longBitsToDouble(ref.get())
+
+  def set(newValue: Double): Unit =
+    ref.set(java.lang.Double.doubleToLongBits(newValue))
+
+  def compareAndSet(expected: Double, newValue: Double): Boolean =
+    ref.compareAndSet(java.lang.Double.doubleToLongBits(expected), java.lang.Double.doubleToLongBits(newValue))
+
+  def incrementBy(value: Double): Unit = {
+    var loop = true
+
+    while (loop) {
+      val current = get()
+      loop = !compareAndSet(current, current + value)
+    }
+  }
+}
+
+object AtomicDouble {
+
+  def apply(value: Double): AtomicDouble =
+    new AtomicDouble(new AtomicLong(java.lang.Double.doubleToLongBits(value)))
+
+}

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/AtomicDouble.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/AtomicDouble.scala
@@ -2,7 +2,7 @@ package zio.telemetry.opentelemetry.metrics.internal
 
 import java.util.concurrent.atomic.AtomicLong
 
-final class AtomicDouble(val ref: AtomicLong) extends AnyVal {
+private[metrics] final class AtomicDouble(val ref: AtomicLong) extends AnyVal {
 
   def get(): Double =
     java.lang.Double.longBitsToDouble(ref.get())
@@ -23,7 +23,7 @@ final class AtomicDouble(val ref: AtomicLong) extends AnyVal {
   }
 }
 
-object AtomicDouble {
+private[metrics] object AtomicDouble {
 
   def apply(value: Double): AtomicDouble =
     new AtomicDouble(new AtomicLong(java.lang.Double.doubleToLongBits(value)))

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/Instrument.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/Instrument.scala
@@ -1,0 +1,154 @@
+package zio.telemetry.opentelemetry.metrics.internal
+
+import zio.telemetry.opentelemetry.metrics.Counter
+import io.opentelemetry.api
+import zio.telemetry.opentelemetry.context.ContextStorage
+import zio.telemetry.opentelemetry.metrics.Histogram
+import zio.telemetry.opentelemetry.metrics.UpDownCounter
+import zio._
+import io.opentelemetry.context.Context
+import zio.telemetry.opentelemetry.metrics.ObservableMeasurement
+
+trait Instrument[-A] {
+
+  def record0(
+    value: A,
+    attributes: api.common.Attributes = api.common.Attributes.empty,
+    context: Context = Context.root()
+  ): Unit
+
+}
+
+object Instrument {
+
+  trait Builder {
+
+    def counter(name: String, unit: Option[String] = None, description: Option[String] = None): Counter[Long]
+
+    def upDownCounter(
+      name: String,
+      unit: Option[String] = None,
+      description: Option[String] = None
+    ): UpDownCounter[Long]
+
+    def histogram(name: String, unit: Option[String] = None, description: Option[String] = None): Histogram[Double]
+
+    def observableCounter(
+      name: String,
+      unit: Option[String] = None,
+      description: Option[String] = None
+    )(callback: ObservableMeasurement[Long] => Unit): api.metrics.ObservableLongCounter
+
+    def observableUpDownCounter(
+      name: String,
+      unit: Option[String] = None,
+      description: Option[String] = None
+    )(callback: ObservableMeasurement[Long] => Unit): api.metrics.ObservableLongUpDownCounter
+
+    def observableGauge(
+      name: String,
+      unit: Option[String] = None,
+      description: Option[String] = None
+    )(callback: ObservableMeasurement[Double] => Unit): api.metrics.ObservableDoubleGauge
+
+  }
+
+  object Builder {
+
+    def live: URLayer[api.metrics.Meter with ContextStorage, Builder] =
+      ZLayer(
+        for {
+          meter      <- ZIO.service[api.metrics.Meter]
+          ctxStorage <- ZIO.service[ContextStorage]
+        } yield new Builder {
+
+          override def counter(
+            name: String,
+            unit: Option[String] = None,
+            description: Option[String] = None
+          ): Counter[Long] = {
+            val builder = meter.counterBuilder(name)
+
+            unit.foreach(builder.setUnit)
+            description.foreach(builder.setDescription)
+
+            Counter.long(builder.build(), ctxStorage)
+          }
+
+          override def upDownCounter(
+            name: String,
+            unit: Option[String] = None,
+            description: Option[String] = None
+          ): UpDownCounter[Long] = {
+            val builder = meter.upDownCounterBuilder(name)
+
+            unit.foreach(builder.setUnit)
+            description.foreach(builder.setDescription)
+
+            UpDownCounter.long(builder.build(), ctxStorage)
+          }
+
+          override def histogram(
+            name: String,
+            unit: Option[String] = None,
+            description: Option[String] = None
+          ): Histogram[Double] = {
+            val builder = meter.histogramBuilder(name)
+
+            unit.foreach(builder.setUnit)
+            description.foreach(builder.setDescription)
+
+            Histogram.double(builder.build(), ctxStorage)
+          }
+
+          override def observableCounter(
+            name: String,
+            unit: Option[String] = None,
+            description: Option[String] = None
+          )(callback: ObservableMeasurement[Long] => Unit): api.metrics.ObservableLongCounter = {
+            val builder = meter.counterBuilder(name)
+
+            unit.foreach(builder.setUnit)
+            description.foreach(builder.setDescription)
+
+            builder.buildWithCallback { om =>
+              callback(ObservableMeasurement.long(om))
+            }
+          }
+
+          override def observableUpDownCounter(
+            name: String,
+            unit: Option[String],
+            description: Option[String]
+          )(callback: ObservableMeasurement[Long] => Unit): api.metrics.ObservableLongUpDownCounter = {
+            val builder = meter.upDownCounterBuilder(name)
+
+            unit.foreach(builder.setUnit)
+            description.foreach(builder.setDescription)
+
+            builder.buildWithCallback { om =>
+              callback(ObservableMeasurement.long(om))
+            }
+          }
+
+          override def observableGauge(
+            name: String,
+            unit: Option[String],
+            description: Option[String]
+          )(callback: ObservableMeasurement[Double] => Unit): api.metrics.ObservableDoubleGauge = {
+            val builder = meter.gaugeBuilder(name)
+
+            unit.foreach(builder.setUnit)
+            description.foreach(builder.setDescription)
+
+            builder.buildWithCallback { om =>
+              callback(ObservableMeasurement.double(om))
+            }
+          }
+
+        }
+      )
+
+  }
+
+}

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/Instrument.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/Instrument.scala
@@ -1,13 +1,10 @@
 package zio.telemetry.opentelemetry.metrics.internal
 
-import zio.telemetry.opentelemetry.metrics.Counter
 import io.opentelemetry.api
-import zio.telemetry.opentelemetry.context.ContextStorage
-import zio.telemetry.opentelemetry.metrics.Histogram
-import zio.telemetry.opentelemetry.metrics.UpDownCounter
-import zio._
 import io.opentelemetry.context.Context
-import zio.telemetry.opentelemetry.metrics.ObservableMeasurement
+import zio._
+import zio.telemetry.opentelemetry.context.ContextStorage
+import zio.telemetry.opentelemetry.metrics.{Counter, Histogram, ObservableMeasurement, UpDownCounter}
 
 trait Instrument[-A] {
 

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/Instrument.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/Instrument.scala
@@ -50,7 +50,7 @@ object Instrument {
 
   }
 
-  object Builder {
+  private[opentelemetry] object Builder {
 
     def live: URLayer[api.metrics.Meter with ContextStorage, Builder] =
       ZLayer(

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/InstrumentRegistry.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/InstrumentRegistry.scala
@@ -1,11 +1,10 @@
 package zio.telemetry.opentelemetry.metrics.internal
 
-import java.util.concurrent.ConcurrentHashMap
-import zio.metrics.MetricKey
-import zio.metrics.MetricKeyType
-import zio.telemetry.opentelemetry.metrics.Counter
-import zio.telemetry.opentelemetry.metrics.Histogram
 import zio._
+import zio.metrics.{MetricKey, MetricKeyType}
+import zio.telemetry.opentelemetry.metrics.{Counter, Histogram}
+
+import java.util.concurrent.ConcurrentHashMap
 
 trait InstrumentRegistry {
 

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/InstrumentRegistry.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/InstrumentRegistry.scala
@@ -16,7 +16,7 @@ trait InstrumentRegistry {
 
 }
 
-object InstrumentRegistry {
+private[opentelemetry] object InstrumentRegistry {
 
   def concurrent: URLayer[Instrument.Builder, InstrumentRegistry] =
     ZLayer(

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/InstrumentRegistry.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/InstrumentRegistry.scala
@@ -1,0 +1,71 @@
+package zio.telemetry.opentelemetry.metrics.internal
+
+import java.util.concurrent.ConcurrentHashMap
+import zio.metrics.MetricKey
+import zio.metrics.MetricKeyType
+import zio.telemetry.opentelemetry.metrics.Counter
+import zio.telemetry.opentelemetry.metrics.Histogram
+import zio._
+
+trait InstrumentRegistry {
+
+  def getCounter(key: MetricKey.Counter): Counter[Long]
+
+  def getHistorgram(key: MetricKey.Histogram): Histogram[Double]
+
+  def getGauge(key: MetricKey.Gauge): AtomicDouble
+
+}
+
+object InstrumentRegistry {
+
+  def concurrent: URLayer[Instrument.Builder, InstrumentRegistry] =
+    ZLayer(
+      for {
+        builder <- ZIO.service[Instrument.Builder]
+      } yield new InstrumentRegistry {
+
+        val map: ConcurrentHashMap[MetricKey[MetricKeyType], Instrument[_]] =
+          new ConcurrentHashMap[MetricKey[MetricKeyType], Instrument[_]]()
+
+        val gauges: ConcurrentHashMap[MetricKey.Gauge, AtomicDouble] =
+          new ConcurrentHashMap[MetricKey.Gauge, AtomicDouble]()
+
+        def getCounter(key: MetricKey.Counter): Counter[Long] =
+          getOrCreateInstrument[Counter, Long](key)(builder.counter(key.name, description = key.description))
+
+        def getHistorgram(key: MetricKey.Histogram): Histogram[Double] =
+          getOrCreateInstrument[Histogram, Double](key)(builder.histogram(key.name, description = key.description))
+
+        def getGauge(key: MetricKey.Gauge): AtomicDouble =
+          gauges.computeIfAbsent(
+            key,
+            { gaugeKey =>
+              val ref = AtomicDouble(0)
+
+              val _ = builder.observableGauge(gaugeKey.name, description = gaugeKey.description) { om =>
+                om.record0(ref.get(), attributes(gaugeKey.tags))
+              }
+
+              ref
+            }
+          )
+
+        private def getOrCreateInstrument[I[_] <: Instrument[_], A](
+          key: MetricKey[MetricKeyType]
+        )(build: => I[A]): I[A] = {
+          var value = map.get(key)
+
+          if (value eq null) {
+            val counter = build
+            map.putIfAbsent(key, counter)
+            value = map.get(key)
+          }
+
+          value.asInstanceOf[I[A]]
+        }
+
+      }
+    )
+
+}

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/OtelMetricListener.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/OtelMetricListener.scala
@@ -36,6 +36,7 @@ private[opentelemetry] object OtelMetricListener {
             .getCounter(key.copy[MetricKeyType.Counter](key.name, MetricKeyType.Counter, key.tags))
             .record0(1L, attributes(key.tags + MetricLabel("bucket", value)))
 
+        // TODO: implement. One of the candidates to look at for inspiration is the micrometer library.
         override def updateSummary(key: MetricKey[MetricKeyType.Summary], value: Double, instant: Instant)(implicit
           unsafe: Unsafe
         ): Unit =

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/OtelMetricListener.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/OtelMetricListener.scala
@@ -1,0 +1,46 @@
+package zio.telemetry.opentelemetry.metrics.internal
+
+import zio.metrics.MetricListener
+import zio.Unsafe
+import java.time.Instant
+import zio.metrics.{MetricKey, MetricKeyType}
+import zio._
+
+object OtelMetricListener {
+
+  def zioMetrics: URLayer[InstrumentRegistry, MetricListener] =
+    ZLayer(
+      for {
+        registry <- ZIO.service[InstrumentRegistry]
+      } yield new MetricListener {
+
+        override def modifyGauge(key: MetricKey[MetricKeyType.Gauge], value: Double)(implicit unsafe: Unsafe): Unit =
+          registry.getGauge(key).incrementBy(value)
+
+        override def updateGauge(key: MetricKey[MetricKeyType.Gauge], value: Double)(implicit unsafe: Unsafe): Unit =
+          registry.getGauge(key).set(value)
+
+        override def updateHistogram(key: MetricKey[MetricKeyType.Histogram], value: Double)(implicit
+          unsafe: Unsafe
+        ): Unit =
+          registry.getHistorgram(key).record0(value, attributes(key.tags))
+
+        override def updateCounter(key: MetricKey[MetricKeyType.Counter], value: Double)(implicit
+          unsafe: Unsafe
+        ): Unit =
+          registry.getCounter(key).record0(value.toLong, attributes(key.tags))
+
+        override def updateFrequency(key: MetricKey[MetricKeyType.Frequency], value: String)(implicit
+          unsafe: Unsafe
+        ): Unit =
+          ()
+
+        override def updateSummary(key: MetricKey[MetricKeyType.Summary], value: Double, instant: Instant)(implicit
+          unsafe: Unsafe
+        ): Unit =
+          ()
+
+      }
+    )
+
+}

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/OtelMetricListener.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/OtelMetricListener.scala
@@ -5,7 +5,7 @@ import zio.{Unsafe, _}
 
 import java.time.Instant
 
-object OtelMetricListener {
+private[opentelemetry] object OtelMetricListener {
 
   def zioMetrics: URLayer[InstrumentRegistry, MetricListener] =
     ZLayer(

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/OtelMetricListener.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/OtelMetricListener.scala
@@ -4,6 +4,7 @@ import zio.metrics.{MetricKey, MetricKeyType, MetricListener}
 import zio.{Unsafe, _}
 
 import java.time.Instant
+import zio.metrics.MetricLabel
 
 object OtelMetricListener {
 
@@ -32,7 +33,9 @@ object OtelMetricListener {
         override def updateFrequency(key: MetricKey[MetricKeyType.Frequency], value: String)(implicit
           unsafe: Unsafe
         ): Unit =
-          ()
+          registry
+            .getCounter(key.copy[MetricKeyType.Counter](key.name, MetricKeyType.Counter, key.tags))
+            .record0(1L, attributes(key.tags + MetricLabel("bucket", value)))
 
         override def updateSummary(key: MetricKey[MetricKeyType.Summary], value: Double, instant: Instant)(implicit
           unsafe: Unsafe

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/OtelMetricListener.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/OtelMetricListener.scala
@@ -1,10 +1,9 @@
 package zio.telemetry.opentelemetry.metrics.internal
 
-import zio.metrics.{MetricKey, MetricKeyType, MetricListener}
+import zio.metrics.{MetricKey, MetricKeyType, MetricLabel, MetricListener}
 import zio.{Unsafe, _}
 
 import java.time.Instant
-import zio.metrics.MetricLabel
 
 object OtelMetricListener {
 

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/OtelMetricListener.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/OtelMetricListener.scala
@@ -1,10 +1,9 @@
 package zio.telemetry.opentelemetry.metrics.internal
 
-import zio.metrics.MetricListener
-import zio.Unsafe
+import zio.metrics.{MetricKey, MetricKeyType, MetricListener}
+import zio.{Unsafe, _}
+
 import java.time.Instant
-import zio.metrics.{MetricKey, MetricKeyType}
-import zio._
 
 object OtelMetricListener {
 

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/package.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/package.scala
@@ -6,7 +6,7 @@ import zio.telemetry.opentelemetry.common.{Attribute, Attributes}
 
 package object internal {
 
-  def attributes(tags: Set[MetricLabel]): api.common.Attributes =
+  private[metrics] def attributes(tags: Set[MetricLabel]): api.common.Attributes =
     Attributes(tags.map(t => Attribute.string(t.key, t.value)).toSeq: _*)
 
 }

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/package.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/package.scala
@@ -1,0 +1,13 @@
+package zio.telemetry.opentelemetry.metrics
+
+import zio.metrics.MetricLabel
+import zio.telemetry.opentelemetry.common.Attribute
+import io.opentelemetry.api
+import zio.telemetry.opentelemetry.common.Attributes
+
+package object internal {
+
+  def attributes(tags: Set[MetricLabel]): api.common.Attributes =
+    Attributes(tags.map(t => Attribute.string(t.key, t.value)).toSeq: _*)
+
+}

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/package.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/package.scala
@@ -1,9 +1,8 @@
 package zio.telemetry.opentelemetry.metrics
 
-import zio.metrics.MetricLabel
-import zio.telemetry.opentelemetry.common.Attribute
 import io.opentelemetry.api
-import zio.telemetry.opentelemetry.common.Attributes
+import zio.metrics.MetricLabel
+import zio.telemetry.opentelemetry.common.{Attribute, Attributes}
 
 package object internal {
 

--- a/opentelemetry/src/test/scala/zio/telemetry/opentelemetry/baggage/BaggageTest.scala
+++ b/opentelemetry/src/test/scala/zio/telemetry/opentelemetry/baggage/BaggageTest.scala
@@ -14,7 +14,7 @@ object BaggageTest extends ZIOSpecDefault {
     ContextStorage.fiberRef >>> Baggage.live()
 
   def logAnnotatedBaggageLayer: ULayer[Baggage] =
-    (ContextStorage.fiberRef >>> Baggage.logAnnotated)
+    (ContextStorage.fiberRef >>> Baggage.live(logAnnotated = true))
 
   def spec: Spec[Environment with TestEnvironment with Scope, Any] =
     suite("zio opentelemetry")(

--- a/opentelemetry/src/test/scala/zio/telemetry/opentelemetry/metrics/MeterTest.scala
+++ b/opentelemetry/src/test/scala/zio/telemetry/opentelemetry/metrics/MeterTest.scala
@@ -5,9 +5,9 @@ import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader
 import zio._
 import zio.telemetry.opentelemetry.common.{Attribute, Attributes}
 import zio.telemetry.opentelemetry.context.ContextStorage
+import zio.telemetry.opentelemetry.metrics.internal.Instrument
 import zio.telemetry.opentelemetry.tracing.{Tracing, TracingTest}
 import zio.test.{TestEnvironment, ZIOSpecDefault, _}
-import zio.telemetry.opentelemetry.metrics.internal.Instrument
 
 import scala.jdk.CollectionConverters._
 
@@ -16,7 +16,7 @@ object MeterTest extends ZIOSpecDefault {
   val inMemoryMetricReaderLayer: ZLayer[Any, Nothing, InMemoryMetricReader] =
     ZLayer(ZIO.succeed(InMemoryMetricReader.create()))
 
-  val meterLayer = {
+  val meterLayer: ZLayer[InMemoryMetricReader with ContextStorage,Nothing,Meter] = {
     val jmeter  = ZLayer {
       for {
         metricReader  <- ZIO.service[InMemoryMetricReader]

--- a/opentelemetry/src/test/scala/zio/telemetry/opentelemetry/metrics/MeterTest.scala
+++ b/opentelemetry/src/test/scala/zio/telemetry/opentelemetry/metrics/MeterTest.scala
@@ -16,7 +16,7 @@ object MeterTest extends ZIOSpecDefault {
   val inMemoryMetricReaderLayer: ZLayer[Any, Nothing, InMemoryMetricReader] =
     ZLayer(ZIO.succeed(InMemoryMetricReader.create()))
 
-  val meterLayer: ZLayer[InMemoryMetricReader with ContextStorage,Nothing,Meter] = {
+  val meterLayer: ZLayer[InMemoryMetricReader with ContextStorage, Nothing, Meter] = {
     val jmeter  = ZLayer {
       for {
         metricReader  <- ZIO.service[InMemoryMetricReader]

--- a/scala-cli/opentelemetry/MetricsApp.scala
+++ b/scala-cli/opentelemetry/MetricsApp.scala
@@ -1,6 +1,6 @@
 //> using scala "2.13.13"
 //> using dep dev.zio::zio:2.0.22
-//> using dep dev.zio::zio-opentelemetry:3.0.0-RC21
+//> using dep dev.zio::zio-opentelemetry:3.0.0-RC22
 //> using dep io.opentelemetry:opentelemetry-sdk:1.37.0
 //> using dep io.opentelemetry:opentelemetry-sdk-trace:1.37.0
 //> using dep io.opentelemetry:opentelemetry-exporter-logging-otlp:1.37.0
@@ -131,7 +131,7 @@ object MetricsApp extends ZIOAppDefault {
       .provide(
         otelSdkLayer,
         ContextStorage.fiberRef,
-        OpenTelemetry.meter(instrumentationScopeName),
+        OpenTelemetry.metrics(instrumentationScopeName),
         OpenTelemetry.tracing(instrumentationScopeName),
         tickCounterLayer,
         tickRefLayer


### PR DESCRIPTION
# What

- Integration with the built-in ZIO Metrics to propagate the ZIO runtime and JVM metrics.
- It lacks the support for https://zio.dev/reference/observability/metrics/summary/ metric type. Micrometer can be used as a reference since it does a translation from Summary to Histogram due to the absence of Summary metric signal in OTEL standard (it is actually deprecated). I've created a separate issue for this https://github.com/zio/zio-telemetry/issues/821.

