### PR TITLE
Pass ZIO Metrics histogram boundaries to OTEL

### DIFF
--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/InstrumentRegistry.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/InstrumentRegistry.scala
@@ -10,7 +10,7 @@ trait InstrumentRegistry {
 
   def getCounter(key: MetricKey.Counter): Counter[Long]
 
-  def getHistorgram(key: MetricKey.Histogram): Histogram[Double]
+  def getHistogram(key: MetricKey.Histogram): Histogram[Double]
 
   def getGauge(key: MetricKey.Gauge): AtomicDouble
 
@@ -33,8 +33,10 @@ private[opentelemetry] object InstrumentRegistry {
         def getCounter(key: MetricKey.Counter): Counter[Long] =
           getOrCreateInstrument[Counter, Long](key)(builder.counter(key.name, description = key.description))
 
-        def getHistorgram(key: MetricKey.Histogram): Histogram[Double] =
-          getOrCreateInstrument[Histogram, Double](key)(builder.histogram(key.name, description = key.description))
+        def getHistogram(key: MetricKey.Histogram): Histogram[Double] =
+          getOrCreateInstrument[Histogram, Double](key)(
+            builder.histogram(key.name, description = key.description, boundaries = Some(key.keyType.boundaries.values))
+          )
 
         def getGauge(key: MetricKey.Gauge): AtomicDouble =
           gauges.computeIfAbsent(

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/OtelMetricListener.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/OtelMetricListener.scala
@@ -22,7 +22,7 @@ private[opentelemetry] object OtelMetricListener {
         override def updateHistogram(key: MetricKey[MetricKeyType.Histogram], value: Double)(implicit
           unsafe: Unsafe
         ): Unit =
-          registry.getHistorgram(key).record0(value, attributes(key.tags))
+          registry.getHistogram(key).record0(value, attributes(key.tags))
 
         override def updateCounter(key: MetricKey[MetricKeyType.Counter], value: Double)(implicit
           unsafe: Unsafe

--- a/opentelemetry/src/test/scala/zio/telemetry/opentelemetry/metrics/MeterTest.scala
+++ b/opentelemetry/src/test/scala/zio/telemetry/opentelemetry/metrics/MeterTest.scala
@@ -3,8 +3,8 @@ package zio.telemetry.opentelemetry.metrics
 import io.opentelemetry.sdk.metrics.SdkMeterProvider
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader
 import zio._
-import zio.metrics.MetricKeyType.Histogram.Boundaries
 import zio.metrics.Metric
+import zio.metrics.MetricKeyType.Histogram.Boundaries
 import zio.telemetry.opentelemetry.OpenTelemetry
 import zio.telemetry.opentelemetry.common.{Attribute, Attributes}
 import zio.telemetry.opentelemetry.context.ContextStorage


### PR DESCRIPTION
Currently boundaries are ignored and default OTEL ones are used.