### PR TITLE
Fix Attributes.apply methods resolution

### DIFF
--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/common/Attributes.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/common/Attributes.scala
@@ -10,7 +10,7 @@ object Attributes {
   def empty: api.common.Attributes =
     api.common.Attributes.empty()
 
-  def apply[T](attributes: Attribute[T]*): api.common.Attributes = {
+  def fromList[T](attributes: List[Attribute[T]]): api.common.Attributes = {
     val builder = api.common.Attributes.builder()
 
     attributes.foreach(attr => builder.put(attr.key, attr.value))

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/package.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/metrics/internal/package.scala
@@ -8,7 +8,7 @@ import zio.telemetry.opentelemetry.common.{Attribute, Attributes}
 package object internal {
 
   private[metrics] def attributes(tags: Set[MetricLabel]): api.common.Attributes =
-    Attributes(tags.map(t => Attribute.string(t.key, t.value)).toSeq: _*)
+    Attributes.fromList(tags.map(t => Attribute.string(t.key, t.value)).toList)
 
   private[metrics] def logAnnotatedAttributes(attributes: api.common.Attributes, logAnnotated: Boolean)(implicit
     trace: Trace
@@ -16,7 +16,7 @@ package object internal {
     if (logAnnotated)
       for {
         annotations <- ZIO.logAnnotations
-        annotated    = Attributes(annotations.map { case (k, v) => Attribute.string(k, v) }.toSeq: _*)
+        annotated    = Attributes.fromList(annotations.map { case (k, v) => Attribute.string(k, v) }.toList)
         builder      = api.common.Attributes.builder()
         _            = builder.putAll(annotated)
         _            = builder.putAll(attributes)

--- a/opentelemetry/src/test/scala/zio/telemetry/opentelemetry/common/AttributesSpec.scala
+++ b/opentelemetry/src/test/scala/zio/telemetry/opentelemetry/common/AttributesSpec.scala
@@ -1,7 +1,6 @@
 package zio.telemetry.opentelemetry.common
 
-import zio.test.ZIOSpecDefault
-import zio.test._
+import zio.test.{ZIOSpecDefault, _}
 
 object AttributesSpec extends ZIOSpecDefault {
 

--- a/opentelemetry/src/test/scala/zio/telemetry/opentelemetry/common/AttributesSpec.scala
+++ b/opentelemetry/src/test/scala/zio/telemetry/opentelemetry/common/AttributesSpec.scala
@@ -1,0 +1,20 @@
+package zio.telemetry.opentelemetry.common
+
+import zio.test.ZIOSpecDefault
+import zio.test._
+
+object AttributesSpec extends ZIOSpecDefault {
+
+  override def spec: Spec[Any, Throwable] =
+    suite("zio opentelemetry")(
+      suite("Attributes")(
+        // Addresses the bug: https://github.com/zio/zio-telemetry/issues/911
+        test("Check methods resolution in compile time") {
+          val _ = Attributes(Attribute.string("foo", "bar"), Attribute.string("dog", "fox"))
+
+          assertTrue(true);
+        }
+      )
+    )
+
+}


### PR DESCRIPTION
Addresses #911 

This fix causes binary incompatibility. I think it is acceptable to release it as a minor version though, because it is a very minor change and shouldn't be a big deal for most users to adjust their code.