### PR TITLE
support varying attribute types in Attributes.fromList

### DIFF
--- a/opentelemetry-core/src/main/scala/zio/telemetry/opentelemetry/core/common/Attributes.scala
+++ b/opentelemetry-core/src/main/scala/zio/telemetry/opentelemetry/core/common/Attributes.scala
@@ -1,6 +1,7 @@
 package zio.telemetry.opentelemetry.core.common
 
 import io.opentelemetry.api
+import io.opentelemetry.api.common.AttributesBuilder
 
 /**
  * Scala helpers to build [[io.opentelemetry.api.common.Attributes]]
@@ -10,10 +11,13 @@ object Attributes {
   def empty: api.common.Attributes =
     api.common.Attributes.empty()
 
-  def fromList[T](attributes: List[Attribute[T]]): api.common.Attributes = {
+  private def putAttribute[T](builder: AttributesBuilder, attr: Attribute[T]): AttributesBuilder =
+    builder.put(attr.key, attr.value)
+
+  def fromList(attributes: List[Attribute[_]]): api.common.Attributes = {
     val builder = api.common.Attributes.builder()
 
-    attributes.foreach(attr => builder.put(attr.key, attr.value))
+    attributes.foreach(attr => putAttribute(builder, attr))
     builder.build()
   }
 

--- a/opentelemetry/src/test/scala/zio/telemetry/opentelemetry/core/common/AttributesSpec.scala
+++ b/opentelemetry/src/test/scala/zio/telemetry/opentelemetry/core/common/AttributesSpec.scala
@@ -12,6 +12,11 @@ object AttributesSpec extends ZIOSpecDefault {
           val _ = Attributes(Attribute.string("foo", "bar"), Attribute.string("dog", "fox"))
 
           assertTrue(true);
+        },
+        test("fromList accepts attributes of varying types") {
+          val _ = Attributes.fromList(List(Attribute.string("foo", "bar"), Attribute.long("dog", 1)))
+
+          assertTrue(true)
         }
       )
     )


### PR DESCRIPTION
https://discord.com/channels/629491597070827530/639825316021272602/1448191223075569747

Attributes.fromList is defined with a generic T, which prevents adding mixed-type attributes:
```scala
val attributes = List(
  Attribute(AttributeKey.stringKey("foo"), "hello"),
  Attribute(AttributeKey.longKey("bar"), 1L),
)
// not possible
Attributes.fromList(attributes)
```
