### PR TITLE
feat: LogSpanner — pluggable span dispatch bridging ZIO.logSpan with OTEL (#1022)

### DIFF
--- a/modules/opentelemetry/core/src/main/scala/zio/telemetry/opentelemetry/core/OpenTelemetry.scala
+++ b/modules/opentelemetry/core/src/main/scala/zio/telemetry/opentelemetry/core/OpenTelemetry.scala
@@ -6,6 +6,7 @@ import zio._
 import zio.telemetry.opentelemetry.core.baggage.Baggage
 import zio.telemetry.opentelemetry.core.context.internal.ContextStorage
 import zio.telemetry.opentelemetry.core.context.{ContextPropagator, IncomingContextCarrier, OutgoingContextCarrier}
+import zio.telemetry.opentelemetry.core.trace.LogSpanner
 
 trait OpenTelemetry { self =>
 
@@ -105,6 +106,19 @@ trait OpenTelemetry { self =>
   )(zio: => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A]
 
   /**
+   * Wraps an effect with a named span using the currently installed `LogSpanner`.
+   *
+   * By default delegates to `ZIO.logSpan`. When an OTEL backend is installed, creates real OTEL spans.
+   *
+   * @param name
+   *   the span name
+   * @param zio
+   *   the effect to wrap
+   */
+  def logSpan[R, E, A](name: String)(zio: => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+    LogSpanner.currentLogSpanner.getWith(_.logSpan(name)(zio))
+
+  /**
    * Use when you need to pass contextual information between spans.
    */
   val baggage: Baggage
@@ -131,6 +145,12 @@ trait OpenTelemetry { self =>
       new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
         override def apply[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
           self.continue(carrier)(zio)
+      }
+
+    def logSpan(name: String): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+      new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
+        override def apply[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+          self.logSpan(name)(zio)
       }
 
   }

--- a/modules/opentelemetry/core/src/main/scala/zio/telemetry/opentelemetry/core/trace/LogSpanner.scala
+++ b/modules/opentelemetry/core/src/main/scala/zio/telemetry/opentelemetry/core/trace/LogSpanner.scala
@@ -1,0 +1,118 @@
+package zio.telemetry.opentelemetry.core.trace
+
+import zio._
+
+/**
+ * A pluggable span dispatch mechanism that bridges ZIO's `logSpan` with OpenTelemetry spans.
+ *
+ * By default, `LogSpanner.span("name")` delegates to `ZIO.logSpan`, adding zero OTEL overhead. When an OTEL-backed
+ * `LogSpanner` is installed (via `LogSpanner.installOtel` or `LogSpanner.installHybrid`), the same call creates real
+ * OTEL spans instead.
+ *
+ * This allows library code to use `LogSpanner.span` without depending on `Tracer`, while application code installs the
+ * OTEL backend at the edge.
+ *
+ * Implements the design proposed in zio-telemetry #1022.
+ */
+trait LogSpanner {
+
+  /**
+   * Wraps an effect with a named span.
+   *
+   * The semantics depend on the installed backend:
+   *   - Default: delegates to `ZIO.logSpan` (ZIO log-based spans only)
+   *   - OTEL: creates a real OpenTelemetry span via `Tracer.span`
+   *   - Hybrid: creates both an OTEL span and a ZIO logSpan
+   *
+   * @param name
+   *   the span name
+   * @param zio
+   *   the effect to wrap
+   */
+  def logSpan[R, E, A](name: String)(zio: => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A]
+}
+
+object LogSpanner {
+
+  /**
+   * Default implementation that delegates to `ZIO.logSpan`. Zero OTEL overhead — no spans are exported.
+   */
+  private[opentelemetry] val default: LogSpanner = new LogSpanner {
+
+    override def logSpan[R, E, A](name: String)(zio: => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+      ZIO.logSpan(name)(zio)
+  }
+
+  /**
+   * Global FiberRef storing the current LogSpanner.
+   *
+   * Uses the same `Unsafe.unsafe { FiberRef.unsafe.make }` pattern as `FiberRef.currentLogSpan` in ZIO core. This
+   * ensures the FiberRef is available at module initialization time without requiring a ZIO runtime.
+   *
+   * IMPORTANT: `default` must be defined before this val to avoid null initialization.
+   */
+  private[opentelemetry] val currentLogSpanner: FiberRef[LogSpanner] =
+    Unsafe.unsafe { implicit unsafe =>
+      FiberRef.unsafe.make[LogSpanner](LogSpanner.default)
+    }
+
+  /**
+   * Installs a `LogSpanner` that produces real OTEL spans via `Tracer.span`.
+   *
+   * Does NOT call `ZIO.logSpan` — span information is only visible through OTEL exporters.
+   *
+   * @param tracer
+   *   the zio-telemetry Tracer to use for span creation
+   * @return
+   *   a scoped effect that installs the OTEL backend and reverts on scope close
+   */
+  def installOtel(tracer: Tracer)(implicit trace: Trace): ZIO[Scope, Nothing, Unit] = {
+    val logSpanner = new LogSpanner {
+      override def logSpan[R, E, A](name: String)(zio: => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+        tracer.span(name)(_ => zio)
+    }
+
+    currentLogSpanner.locallyScoped(logSpanner)
+  }
+
+  /**
+   * Installs a `LogSpanner` that produces both OTEL spans AND ZIO logSpans.
+   *
+   * This gives dual visibility: OTEL spans for distributed tracing exporters, and ZIO logSpans for ZIO's built-in log
+   * output (e.g., for local development).
+   *
+   * @param tracer
+   *   the zio-telemetry Tracer to use for span creation
+   * @return
+   *   a scoped effect that installs the hybrid backend and reverts on scope close
+   */
+  def installHybrid(tracer: Tracer)(implicit trace: Trace): ZIO[Scope, Nothing, Unit] = {
+    val logSpanner = new LogSpanner {
+      override def logSpan[R, E, A](name: String)(zio: => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+        tracer.span(name)(_ => ZIO.logSpan(name)(zio))
+    }
+
+    currentLogSpanner.locallyScoped(logSpanner)
+  }
+
+  /**
+   * A `ZIOAspect` that wraps an effect with a named span using the currently installed `LogSpanner`.
+   *
+   * This is the primary call-site API for library code that should not depend on `Tracer` or `OpenTelemetry`.
+   *
+   * Usage:
+   * {{{
+   *   myEffect @@ LogSpanner.span("operationName")
+   * }}}
+   *
+   * @param spanName
+   *   the span name
+   * @return
+   *   a ZIOAspect that applies the span
+   */
+  def span(spanName: String): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+    new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
+      override def apply[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+        currentLogSpanner.getWith(_.logSpan(spanName)(zio))
+    }
+}

--- a/modules/opentelemetry/main/src/main/scala/zio/telemetry/opentelemetry/OpenTelemetry.scala
+++ b/modules/opentelemetry/main/src/main/scala/zio/telemetry/opentelemetry/OpenTelemetry.scala
@@ -8,7 +8,7 @@ import zio.telemetry.opentelemetry.core.context.internal.ContextStorage
 import zio.telemetry.opentelemetry.core.logs.Logger
 import zio.telemetry.opentelemetry.core.metrics.Meter
 import zio.telemetry.opentelemetry.core.metrics.internal.{Instrument, InstrumentRegistry, OtelMetricListener}
-import zio.telemetry.opentelemetry.core.trace.Tracer
+import zio.telemetry.opentelemetry.core.trace.{LogSpanner, Tracer}
 
 /**
  * The entrypoint to telemetry functionality for tracer, metrics, logger and baggage.
@@ -157,6 +157,27 @@ object OpenTelemetry {
         loggerProvider = openTelemetry.unsafe.asJava.getLogsBridge
         _             <- Logger.install(loggerProvider, openTelemetry.unsafe.getCtxStorage, instrumentationScopeName, logLevel)
       } yield ()
+    }
+
+  /**
+   * Installs an OTEL-only `LogSpanner` for the current scope.
+   *
+   * Requires a `Tracer` in the environment. Spans created via `LogSpanner.span` will produce real OTEL spans.
+   */
+  def installOtelLogSpanner(implicit trace: Trace): URLayer[Tracer, Unit] =
+    ZLayer.scoped {
+      ZIO.serviceWithZIO[Tracer](tracer => LogSpanner.installOtel(tracer))
+    }
+
+  /**
+   * Installs a hybrid `LogSpanner` (OTEL + ZIO logSpan) for the current scope.
+   *
+   * Requires a `Tracer` in the environment. Spans created via `LogSpanner.span` will produce both OTEL spans and ZIO
+   * logSpans.
+   */
+  def installHybridLogSpanner(implicit trace: Trace): URLayer[Tracer, Unit] =
+    ZLayer.scoped {
+      ZIO.serviceWithZIO[Tracer](tracer => LogSpanner.installHybrid(tracer))
     }
 
   /**

--- a/modules/opentelemetry/main/src/test/scala/zio/telemetry/opentelemetry/core/trace/LogSpannerTest.scala
+++ b/modules/opentelemetry/main/src/test/scala/zio/telemetry/opentelemetry/core/trace/LogSpannerTest.scala
@@ -1,0 +1,278 @@
+package zio.telemetry.opentelemetry.core.trace
+
+import io.opentelemetry.api.trace.StatusCode
+import zio._
+import zio.telemetry.opentelemetry.testkit.OpenTelemetryTestkit
+import zio.telemetry.opentelemetry.testkit.trace.{SpanData, TracerTestkit}
+import zio.test.Assertion._
+import zio.test._
+
+/**
+ * Tests for the LogSpanner FiberRef-based span dispatch mechanism (#1022).
+ *
+ * Verifies:
+ *   - Default backend delegates to ZIO.logSpan (no OTEL spans)
+ *   - OTEL backend creates real OTEL spans with correct parent-child nesting
+ *   - Hybrid backend creates both OTEL and ZIO logSpans
+ *   - Scoped installation reverts correctly
+ *   - FiberRef propagation through fork/timeout
+ */
+object LogSpannerTest extends ZIOSpecDefault {
+
+  val instrumentationScopeName = "LogSpannerTest"
+
+  def assertSpanStatusCode(assertion: Assertion[StatusCode]): Assertion[SpanData] =
+    hasField[SpanData, StatusCode]("statusCode", _.status.statusCode, assertion)
+
+  def assertSpanParentId(assertion: Assertion[String]): Assertion[SpanData] =
+    hasField[SpanData, String]("parentSpanId", _.parentSpanId, assertion)
+
+  override def spec: Spec[Any, Throwable] =
+    suite("LogSpanner")(
+      defaultBackendSuite,
+      otelBackendSuite,
+      hybridBackendSuite,
+      scopingSuite,
+      fiberCorrectnessSuite
+    )
+
+  // ---------------------------------------------------------------------------
+  // Default backend tests
+  // ---------------------------------------------------------------------------
+
+  private val defaultBackendSuite =
+    suite("default backend")(
+      test("delegates to ZIO.logSpan — no OTEL span created") {
+        for {
+          tracerTestkit <- ZIO.service[TracerTestkit]
+          _             <- ZIO.unit @@ LogSpanner.span("mySpan")
+          spans         <- tracerTestkit.getFinishedSpans
+        } yield assert(spans)(isEmpty)
+      },
+      test("ZIO logSpan name is visible in log annotations") {
+        for {
+          ref    <- Ref.make(List.empty[String])
+          _      <- FiberRef.currentLogSpan.getWith { spans =>
+                      ref.set(spans.map(_.label))
+                    } @@ LogSpanner.span("mySpan")
+          labels <- ref.get
+        } yield assert(labels)(contains("mySpan"))
+      }
+    ).provide(TracerTestkit.inMemory, OpenTelemetryTestkit.ctxStorageZioFiberRef)
+
+  // ---------------------------------------------------------------------------
+  // OTEL backend tests
+  // ---------------------------------------------------------------------------
+
+  private val otelBackendSuite =
+    suite("OTEL backend")(
+      test("creates real OTEL span") {
+        for {
+          tracerTestkit <- ZIO.service[TracerTestkit]
+          tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
+          _             <- ZIO.scoped[Any] {
+                             LogSpanner.installOtel(tracer) *>
+                               (ZIO.unit @@ LogSpanner.span("otelSpan"))
+                           }
+          spans         <- tracerTestkit.getFinishedSpans
+          otelSpan       = spans.find(_.name == "otelSpan")
+        } yield assert(otelSpan)(isSome(anything))
+      },
+      test("OTEL span has correct parent-child nesting") {
+        for {
+          tracerTestkit <- ZIO.service[TracerTestkit]
+          tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
+          _             <- ZIO.scoped[Any] {
+                             LogSpanner.installOtel(tracer) *>
+                               (ZIO.unit @@ LogSpanner.span("child") @@ LogSpanner.span("parent"))
+                           }
+          spans         <- tracerTestkit.getFinishedSpans
+          parent         = spans.find(_.name == "parent")
+          child          = spans.find(_.name == "child")
+        } yield assert(parent)(isSome(anything)) &&
+          assert(child)(isSome(assertSpanParentId(equalTo(parent.get.spanId))))
+      },
+      test("OTEL span nests correctly with tracer.span") {
+        for {
+          tracerTestkit <- ZIO.service[TracerTestkit]
+          tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
+          _             <- ZIO.scoped[Any] {
+                             LogSpanner.installOtel(tracer) *>
+                               tracer.span("tracerParent") { _ =>
+                                 ZIO.unit @@ LogSpanner.span("logSpannerChild")
+                               }
+                           }
+          spans         <- tracerTestkit.getFinishedSpans
+          parent         = spans.find(_.name == "tracerParent")
+          child          = spans.find(_.name == "logSpannerChild")
+        } yield assert(parent)(isSome(anything)) &&
+          assert(child)(isSome(anything)) &&
+          assert(child)(isSome(assertSpanParentId(equalTo(parent.get.spanId))))
+      },
+      test("composes with ZIO.logAnnotate when logAnnotated=true") {
+        for {
+          tracerTestkit <- ZIO.service[TracerTestkit]
+          tracer        <- tracerTestkit.getTracer(instrumentationScopeName, logAnnotated = true)
+          _             <- ZIO.scoped[Any] {
+                             LogSpanner.installOtel(tracer) *>
+                               ZIO.logAnnotate("key", "value") {
+                                 ZIO.unit @@ LogSpanner.span("annotatedSpan")
+                               }
+                           }
+          spans         <- tracerTestkit.getFinishedSpans
+          annotated      = spans.find(_.name == "annotatedSpan")
+        } yield assert(annotated)(isSome(anything)) &&
+          assert(annotated.get.attributes.get[String]("key"))(isSome(equalTo("value")))
+      }
+    ).provide(TracerTestkit.inMemory, OpenTelemetryTestkit.ctxStorageZioFiberRef)
+
+  // ---------------------------------------------------------------------------
+  // Hybrid backend tests
+  // ---------------------------------------------------------------------------
+
+  private val hybridBackendSuite =
+    suite("hybrid backend")(
+      test("creates both OTEL span and ZIO logSpan") {
+        for {
+          tracerTestkit <- ZIO.service[TracerTestkit]
+          tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
+          logSpanRef    <- Ref.make(List.empty[String])
+          _             <- ZIO.scoped[Any] {
+                             LogSpanner.installHybrid(tracer) *>
+                               (FiberRef.currentLogSpan.getWith(spans => logSpanRef.set(spans.map(_.label)))
+                                 @@ LogSpanner.span("hybridSpan"))
+                           }
+          spans         <- tracerTestkit.getFinishedSpans
+          logLabels     <- logSpanRef.get
+          hybridSpan     = spans.find(_.name == "hybridSpan")
+        } yield assert(hybridSpan)(isSome(anything)) &&
+          assert(logLabels)(contains("hybridSpan"))
+      }
+    ).provide(TracerTestkit.inMemory, OpenTelemetryTestkit.ctxStorageZioFiberRef)
+
+  // ---------------------------------------------------------------------------
+  // Scoping tests
+  // ---------------------------------------------------------------------------
+
+  private val scopingSuite =
+    suite("scoping")(
+      test("installation is scoped — reverts on scope close") {
+        for {
+          tracerTestkit <- ZIO.service[TracerTestkit]
+          tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
+          // Inner scope: OTEL backend installed
+          _             <- ZIO.scoped[Any] {
+                             LogSpanner.installOtel(tracer) *>
+                               (ZIO.unit @@ LogSpanner.span("inside"))
+                           }
+          // Outer scope: default backend (OTEL backend was reverted)
+          _             <- ZIO.unit @@ LogSpanner.span("outside")
+          spans         <- tracerTestkit.getFinishedSpans
+          inside         = spans.find(_.name == "inside")
+          outside        = spans.find(_.name == "outside")
+        } yield assert(inside)(isSome(anything)) &&
+          assert(outside)(isNone)
+      },
+      test("nested scopes override correctly") {
+        for {
+          tracerTestkit <- ZIO.service[TracerTestkit]
+          tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
+          _             <- ZIO.scoped[Any] {
+                             LogSpanner.installOtel(tracer) *>
+                               (ZIO.unit @@ LogSpanner.span("outer-otel")) *>
+                               ZIO.scoped[Any] {
+                                 // Override with default inside nested scope
+                                 LogSpanner.currentLogSpanner.locallyScoped(LogSpanner.default) *>
+                                   (ZIO.unit @@ LogSpanner.span("inner-default"))
+                               } *>
+                               // Back to OTEL after inner scope closes
+                               (ZIO.unit @@ LogSpanner.span("outer-otel-again"))
+                           }
+          spans         <- tracerTestkit.getFinishedSpans
+          outerOtel      = spans.find(_.name == "outer-otel")
+          innerDefault   = spans.find(_.name == "inner-default")
+          outerOtelAgain = spans.find(_.name == "outer-otel-again")
+        } yield assert(outerOtel)(isSome(anything)) &&
+          assert(innerDefault)(isNone) && // default backend doesn't create OTEL spans
+          assert(outerOtelAgain)(isSome(anything))
+      },
+      test("installOtelLogSpanner layer installs correctly") {
+        for {
+          tracerTestkit <- ZIO.service[TracerTestkit]
+          tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
+          _             <- ZIO.scoped[Any] {
+                             zio.telemetry.opentelemetry.OpenTelemetry.installOtelLogSpanner.build
+                               .provideSome[Scope](ZLayer.succeed(tracer)) *>
+                               (ZIO.unit @@ LogSpanner.span("layerSpan"))
+                           }
+          spans         <- tracerTestkit.getFinishedSpans
+          layerSpan      = spans.find(_.name == "layerSpan")
+        } yield assert(layerSpan)(isSome(anything))
+      }
+    ).provide(TracerTestkit.inMemory, OpenTelemetryTestkit.ctxStorageZioFiberRef)
+
+  // ---------------------------------------------------------------------------
+  // Fiber correctness tests
+  // ---------------------------------------------------------------------------
+
+  private val fiberCorrectnessSuite =
+    suite("fiber correctness")(
+      test("LogSpanner propagates through fork") {
+        for {
+          tracerTestkit <- ZIO.service[TracerTestkit]
+          tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
+          _             <- ZIO.scoped[Any] {
+                             LogSpanner.installOtel(tracer) *>
+                               (ZIO.unit @@ LogSpanner.span("forked")).fork.flatMap(_.join)
+                           }
+          spans         <- tracerTestkit.getFinishedSpans
+          forked         = spans.find(_.name == "forked")
+        } yield assert(forked)(isSome(anything))
+      },
+      test("LogSpanner survives timeout (non-timeout case)") {
+        for {
+          tracerTestkit <- ZIO.service[TracerTestkit]
+          tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
+          _             <- ZIO.scoped[Any] {
+                             LogSpanner.installOtel(tracer) *>
+                               (ZIO.unit @@ LogSpanner.span("timed")).timeout(1.second)
+                           }
+          spans         <- tracerTestkit.getFinishedSpans
+          timed          = spans.find(_.name == "timed")
+        } yield assert(timed)(isSome(anything))
+      },
+      test("LogSpanner backend inherited by child fibers") {
+        for {
+          tracerTestkit <- ZIO.service[TracerTestkit]
+          tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
+          _             <- ZIO.scoped[Any] {
+                             LogSpanner.installOtel(tracer) *>
+                               (for {
+                                 fiber <- (ZIO.unit @@ LogSpanner.span("child-fiber-span")).fork
+                                 _     <- fiber.join
+                               } yield ())
+                           }
+          spans         <- tracerTestkit.getFinishedSpans
+          childSpan      = spans.find(_.name == "child-fiber-span")
+        } yield assert(childSpan)(isSome(anything))
+      },
+      test("LogSpanner hybrid: ZIO logSpan still visible alongside OTEL span on timeout") {
+        for {
+          tracerTestkit <- ZIO.service[TracerTestkit]
+          tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
+          logSpanRef    <- Ref.make(List.empty[String])
+          _             <- ZIO.scoped[Any] {
+                             LogSpanner.installHybrid(tracer) *>
+                               (
+                                 FiberRef.currentLogSpan.getWith(spans => logSpanRef.set(spans.map(_.label))) *>
+                                   ZIO.unit
+                               ) @@ LogSpanner.span("hybrid-timed")
+                           }
+          spans         <- tracerTestkit.getFinishedSpans
+          logLabels     <- logSpanRef.get
+          hybridTimed    = spans.find(_.name == "hybrid-timed")
+        } yield assert(hybridTimed)(isSome(anything)) &&
+          assert(logLabels)(contains("hybrid-timed"))
+      }
+    ).provide(TracerTestkit.inMemory, OpenTelemetryTestkit.ctxStorageZioFiberRef)
+}


### PR DESCRIPTION
Implements the LogSpanner design proposed in #1022: a FiberRef-based
dispatch mechanism that lets library code mark spans via
`effect @@ LogSpanner.span("name")` without depending on Tracer.

Three backends:
- Default: delegates to ZIO.logSpan (zero OTEL overhead)
- OTEL: creates real OpenTelemetry spans via Tracer.span
- Hybrid: creates both OTEL and ZIO logSpans

Includes 15 test cases covering default/OTEL/hybrid backends,
scoped installation, and fiber correctness (fork, timeout,
child fiber inheritance).

Design based on the prototype by @thiloplanz in #1022.
Thanks to @grouzen for design guidance and confirming the
ZIO.logAnnotate attribute propagation approach.