### PR TITLE
fix: ensure interrupted spans record correct status via uninterruptibleMask (partial #1069)

### DIFF
--- a/modules/opentelemetry/core/src/main/scala/zio/telemetry/opentelemetry/core/trace/Tracer.scala
+++ b/modules/opentelemetry/core/src/main/scala/zio/telemetry/opentelemetry/core/trace/Tracer.scala
@@ -378,10 +378,12 @@ private[opentelemetry] object Tracer {
         ctx: Context,
         statusMapper: StatusMapper[E, A]
       )(zio: => ZIO[R, E1, A1])(implicit trace: Trace): ZIO[R, E1, A1] =
-        (for {
-          exit <- ctxStorage.locally(ctx)(zio).exit
-          _    <- statusMapper.handle(Span.fromContext(ctx), exit)
-        } yield exit).unexit
+        ZIO.uninterruptibleMask { restore =>
+          (for {
+            exit <- restore(ctxStorage.locally(ctx)(zio)).exit
+            _    <- statusMapper.handle(Span.fromContext(ctx), exit)
+          } yield exit).unexit
+        }
 
       private def currentNanos(implicit trace: Trace): UIO[Long] =
         Clock.currentTime(TimeUnit.NANOSECONDS)

--- a/modules/opentelemetry/main/src/test/scala/zio/telemetry/opentelemetry/core/trace/InterruptionTracerTest.scala
+++ b/modules/opentelemetry/main/src/test/scala/zio/telemetry/opentelemetry/core/trace/InterruptionTracerTest.scala
@@ -1,0 +1,147 @@
+package zio.telemetry.opentelemetry.core.trace
+
+import io.opentelemetry.api.trace.StatusCode
+import zio._
+import zio.telemetry.opentelemetry.testkit.OpenTelemetryTestkit
+import zio.telemetry.opentelemetry.testkit.trace.{SpanData, TracerTestkit}
+import zio.test.Assertion._
+import zio.test._
+
+/**
+ * Tests verifying that OTEL spans are correctly recorded when effects are interrupted.
+ *
+ * These tests document the behavior described in zio-telemetry #1069. The FiberRef-based ContextStorage path (used by
+ * `OpenTelemetry.custom`) is expected to handle interruption correctly because `Tracer.span` uses
+ * `ZIO.acquireReleaseWith`, which per Zionomicon Ch.14 guarantees that the release (endSpan) runs even on interruption.
+ *
+ * The ThreadLocal-based ContextStorage path (`OpenTelemetry.global`) has known issues with interruption, documented in
+ * the secondary test suite below.
+ */
+object InterruptionTracerTest extends ZIOSpecDefault {
+
+  val instrumentationScopeName = "InterruptionTracerTest"
+
+  def assertSpanStatusCode(assertion: Assertion[StatusCode]): Assertion[SpanData] =
+    hasField[SpanData, StatusCode]("statusCode", _.status.statusCode, assertion)
+
+  def assertSpanParentId(assertion: Assertion[String]): Assertion[SpanData] =
+    hasField[SpanData, String]("parentSpanId", _.parentSpanId, assertion)
+
+  override def spec: Spec[Any, Throwable] =
+    suite("Interrupted span recording")(
+      fiberRefSuite,
+      threadLocalSuite
+    )
+
+  /**
+   * FiberRef ContextStorage tests — these should all PASS on RC10, confirming that #1069 is a ThreadLocal-only issue
+   * for the `acquireReleaseWith` span lifecycle path.
+   */
+  private val fiberRefSuite =
+    suite("FiberRef ContextStorage")(
+      test("timeout: span is recorded with ERROR status when effect times out") {
+        for {
+          tracerTestkit <- ZIO.service[TracerTestkit]
+          tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
+          _             <- tracer.span("slow-op")(_ => ZIO.sleep(1.hour)).timeout(10.millis)
+          spans         <- tracerTestkit.getFinishedSpans
+          slowOp         = spans.find(_.name == "slow-op")
+          // acquireReleaseWith guarantees endSpan runs, and the uninterruptibleMask
+          // fix in contextScope guarantees statusMapper.handle runs before the
+          // interruption propagates — so the span has ERROR status.
+        } yield assert(slowOp)(isSome(anything)) &&
+          assert(slowOp)(isSome(assertSpanStatusCode(equalTo(StatusCode.ERROR))))
+      },
+      test("timeout: parent context preserved after child timeout") {
+        for {
+          tracerTestkit <- ZIO.service[TracerTestkit]
+          tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
+          _             <- tracer.span("parent") { _ =>
+                             tracer.span("child")(_ => ZIO.sleep(1.hour)).timeout(10.millis) *>
+                               tracer.span("sibling")(_ => ZIO.unit)
+                           }
+          spans         <- tracerTestkit.getFinishedSpans
+          parent         = spans.find(_.name == "parent")
+          sibling        = spans.find(_.name == "sibling")
+        } yield assert(parent)(isSome(anything)) &&
+          assert(sibling)(isSome(anything)) &&
+          assert(sibling)(isSome(assertSpanParentId(equalTo(parent.get.spanId))))
+      },
+      test("race: both fast and slow spans are recorded") {
+        for {
+          tracerTestkit <- ZIO.service[TracerTestkit]
+          tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
+          _             <- tracer
+                             .span("fast")(_ => ZIO.unit)
+                             .race(
+                               tracer.span("slow")(_ => ZIO.sleep(1.hour))
+                             )
+          // Allow the losing fiber's finalizer (span.end) to complete
+          _             <- ZIO.sleep(100.millis)
+          spans         <- tracerTestkit.getFinishedSpans
+          fast           = spans.find(_.name == "fast")
+          slow           = spans.find(_.name == "slow")
+        } yield assert(fast)(isSome(anything)) &&
+          assert(slow)(isSome(anything))
+      },
+      test("fork: child fiber span inherits parent context") {
+        for {
+          tracerTestkit <- ZIO.service[TracerTestkit]
+          tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
+          _             <- tracer.span("parent") { _ =>
+                             tracer.span("forked")(_ => ZIO.unit).fork.flatMap(_.join)
+                           }
+          spans         <- tracerTestkit.getFinishedSpans
+          parent         = spans.find(_.name == "parent")
+          forked         = spans.find(_.name == "forked")
+        } yield assert(parent)(isSome(anything)) &&
+          assert(forked)(isSome(anything)) &&
+          assert(forked)(isSome(assertSpanParentId(equalTo(parent.get.spanId))))
+      },
+      test("forkDaemon: span is still recorded") {
+        for {
+          tracerTestkit <- ZIO.service[TracerTestkit]
+          tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
+          promise       <- Promise.make[Nothing, Unit]
+          _             <- tracer.span("daemon-span") { _ =>
+                             (ZIO.unit <* promise.succeed(())).forkDaemon.flatMap(_ => promise.await)
+                           }
+          spans         <- tracerTestkit.getFinishedSpans
+          daemonSpan     = spans.find(_.name == "daemon-span")
+        } yield assert(daemonSpan)(isSome(anything))
+      }
+    ).provide(TracerTestkit.inMemory, OpenTelemetryTestkit.ctxStorageZioFiberRef) @@ TestAspect.withLiveClock
+
+  /**
+   * ThreadLocal ContextStorage tests — these document known #1069 failures. The ThreadLocal-based storage does not
+   * properly propagate context across fiber boundaries, so interruption can lose span context.
+   *
+   * These tests serve as regression tests for a future fix (FiberRef.asThreadLocal bridge).
+   */
+  private val threadLocalSuite =
+    suite("ThreadLocal ContextStorage (known #1069 issues)")(
+      test("timeout: span is recorded when effect times out") {
+        for {
+          tracerTestkit <- ZIO.service[TracerTestkit]
+          tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
+          _             <- tracer.span("slow-op-tl")(_ => ZIO.sleep(1.hour)).timeout(10.millis)
+          spans         <- tracerTestkit.getFinishedSpans
+          slowOp         = spans.find(_.name == "slow-op-tl")
+        } yield assert(slowOp)(isSome(anything))
+      },
+      test("fork: child fiber span inherits parent context") {
+        for {
+          tracerTestkit <- ZIO.service[TracerTestkit]
+          tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
+          _             <- tracer.span("parent-tl") { _ =>
+                             tracer.span("forked-tl")(_ => ZIO.unit).fork.flatMap(_.join)
+                           }
+          spans         <- tracerTestkit.getFinishedSpans
+          parent         = spans.find(_.name == "parent-tl")
+          forked         = spans.find(_.name == "forked-tl")
+        } yield assert(parent)(isSome(anything)) &&
+          assert(forked)(isSome(anything))
+      }
+    ).provide(TracerTestkit.inMemory, OpenTelemetryTestkit.ctxStorageJavaOtelThreadLocal) @@ TestAspect.withLiveClock @@
+      TestAspect.flaky(3) // ThreadLocal path may fail — that's the documented #1069 behavior
+}

--- a/modules/opentelemetry/main/src/test/scala/zio/telemetry/opentelemetry/core/trace/InterruptionTracerTest.scala
+++ b/modules/opentelemetry/main/src/test/scala/zio/telemetry/opentelemetry/core/trace/InterruptionTracerTest.scala
@@ -43,7 +43,7 @@ object InterruptionTracerTest extends ZIOSpecDefault {
         for {
           tracerTestkit <- ZIO.service[TracerTestkit]
           tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
-          _             <- tracer.span("slow-op")(_ => ZIO.sleep(1.hour)).timeout(10.millis)
+          _             <- (ZIO.sleep(1.hour) @@ tracer.aspects.span("slow-op")).timeout(100.millis)
           spans         <- tracerTestkit.getFinishedSpans
           slowOp         = spans.find(_.name == "slow-op")
           // acquireReleaseWith guarantees endSpan runs, and the uninterruptibleMask
@@ -56,10 +56,10 @@ object InterruptionTracerTest extends ZIOSpecDefault {
         for {
           tracerTestkit <- ZIO.service[TracerTestkit]
           tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
-          _             <- tracer.span("parent") { _ =>
-                             tracer.span("child")(_ => ZIO.sleep(1.hour)).timeout(10.millis) *>
-                               tracer.span("sibling")(_ => ZIO.unit)
-                           }
+          _             <- (
+                             (ZIO.sleep(1.hour) @@ tracer.aspects.span("child")).timeout(100.millis) *>
+                               (ZIO.unit @@ tracer.aspects.span("sibling"))
+                           ) @@ tracer.aspects.span("parent")
           spans         <- tracerTestkit.getFinishedSpans
           parent         = spans.find(_.name == "parent")
           sibling        = spans.find(_.name == "sibling")
@@ -71,10 +71,9 @@ object InterruptionTracerTest extends ZIOSpecDefault {
         for {
           tracerTestkit <- ZIO.service[TracerTestkit]
           tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
-          _             <- tracer
-                             .span("fast")(_ => ZIO.unit)
+          _             <- (ZIO.unit @@ tracer.aspects.span("fast"))
                              .race(
-                               tracer.span("slow")(_ => ZIO.sleep(1.hour))
+                               ZIO.sleep(1.hour) @@ tracer.aspects.span("slow")
                              )
           // Allow the losing fiber's finalizer (span.end) to complete
           _             <- ZIO.sleep(100.millis)
@@ -88,9 +87,9 @@ object InterruptionTracerTest extends ZIOSpecDefault {
         for {
           tracerTestkit <- ZIO.service[TracerTestkit]
           tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
-          _             <- tracer.span("parent") { _ =>
-                             tracer.span("forked")(_ => ZIO.unit).fork.flatMap(_.join)
-                           }
+          _             <- (
+                             (ZIO.unit @@ tracer.aspects.span("forked")).fork.flatMap(_.join)
+                           ) @@ tracer.aspects.span("parent")
           spans         <- tracerTestkit.getFinishedSpans
           parent         = spans.find(_.name == "parent")
           forked         = spans.find(_.name == "forked")
@@ -103,9 +102,9 @@ object InterruptionTracerTest extends ZIOSpecDefault {
           tracerTestkit <- ZIO.service[TracerTestkit]
           tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
           promise       <- Promise.make[Nothing, Unit]
-          _             <- tracer.span("daemon-span") { _ =>
+          _             <- (
                              (ZIO.unit <* promise.succeed(())).forkDaemon.flatMap(_ => promise.await)
-                           }
+                           ) @@ tracer.aspects.span("daemon-span")
           spans         <- tracerTestkit.getFinishedSpans
           daemonSpan     = spans.find(_.name == "daemon-span")
         } yield assert(daemonSpan)(isSome(anything))
@@ -124,7 +123,7 @@ object InterruptionTracerTest extends ZIOSpecDefault {
         for {
           tracerTestkit <- ZIO.service[TracerTestkit]
           tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
-          _             <- tracer.span("slow-op-tl")(_ => ZIO.sleep(1.hour)).timeout(10.millis)
+          _             <- (ZIO.sleep(1.hour) @@ tracer.aspects.span("slow-op-tl")).timeout(100.millis)
           spans         <- tracerTestkit.getFinishedSpans
           slowOp         = spans.find(_.name == "slow-op-tl")
         } yield assert(slowOp)(isSome(anything))
@@ -133,9 +132,9 @@ object InterruptionTracerTest extends ZIOSpecDefault {
         for {
           tracerTestkit <- ZIO.service[TracerTestkit]
           tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
-          _             <- tracer.span("parent-tl") { _ =>
-                             tracer.span("forked-tl")(_ => ZIO.unit).fork.flatMap(_.join)
-                           }
+          _             <- (
+                             (ZIO.unit @@ tracer.aspects.span("forked-tl")).fork.flatMap(_.join)
+                           ) @@ tracer.aspects.span("parent-tl")
           spans         <- tracerTestkit.getFinishedSpans
           parent         = spans.find(_.name == "parent-tl")
           forked         = spans.find(_.name == "forked-tl")


### PR DESCRIPTION
This addresses Sub-problem A of #1069: interrupted spans are recorded
with UNSET status instead of ERROR because the interruption signal
races with statusMapper.handle in Tracer.contextScope.

Fix: wrap contextScope's exit/statusMapper sequence in
ZIO.uninterruptibleMask so that statusMapper.handle runs before the
interruption propagates. This is a ~4-line change.

This does NOT address Sub-problem B of #1069: ThreadLocal context
loss when fibers hop threads (affects OpenTelemetry.global / Java
agent auto-instrumentation path only). Sub-problem B requires a
FiberRef.asThreadLocal bridge — a substantially larger effort that
is orthogonal to this fix.

Adds InterruptionTracerTest verifying:
- FiberRef ContextStorage: timeout ERROR status, parent context
  preservation, race, fork, forkDaemon (5 tests, all passing)
- ThreadLocal ContextStorage: documents known #1069 behavior with
  @@ TestAspect.flaky(3) as regression tests for a future fix
  (2 tests)

Thanks to @dontgitit for reporting the timeout context loss in
#1069, and to @grouzen for the discussion on .onExit vs
uninterruptibleMask approaches.