### PR TITLE
CI: Drop JDK 11, add JDK 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,9 @@ jobs:
       fail-fast: false
       matrix:
         java:
-        - '11'
         - '17'
         - '21'
+        - '25'
     steps:
     - name: Install libuv
       run: sudo apt-get update && sudo apt-get install -y libuv1-dev


### PR DESCRIPTION
## Summary

- Drop JDK 11 from the CI test matrix as it is no longer supported
- Add JDK 25 to the CI test matrix
- Test matrix is now: JDK 17, 21, 25