### PR TITLE
add `Cause` variants to `StatusMapper` that allow acting on defects

### DIFF
--- a/modules/opentelemetry/core/src/main/scala/zio/telemetry/opentelemetry/core/trace/StatusMapper.scala
+++ b/modules/opentelemetry/core/src/main/scala/zio/telemetry/opentelemetry/core/trace/StatusMapper.scala
@@ -43,7 +43,7 @@ object StatusMapper {
   }
 
   /**
-   * Default case allows overriding the default behavior from the official specfication:
+   * Default case allows overriding the default behavior from the official specification:
    * [[https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status Set status]]
    *
    * @param success
@@ -51,7 +51,7 @@ object StatusMapper {
    */
   sealed class Default[-E, -A](
     success: PartialFunction[A, Result.Success] = PartialFunction.empty,
-    failure: PartialFunction[E, Result.Failure] = PartialFunction.empty
+    failure: PartialFunction[Cause[E], Result.Failure] = PartialFunction.empty
   ) extends StatusMapper[E, A] {
 
     override def handleSuccess(span: Span, a: A)(implicit trace: Trace): UIO[Unit] =
@@ -68,8 +68,8 @@ object StatusMapper {
 
     override def handleFailure(span: Span, cause: Cause[E])(implicit trace: Trace): UIO[Unit] = {
       val result =
-        cause.failureOption
-          .flatMap(failure.lift)
+        failure
+          .lift(cause)
           .getOrElse(StatusMapper.Result.Failure(StatusCode.ERROR))
 
       for {
@@ -101,10 +101,10 @@ object StatusMapper {
    * @param pf
    *   partial function to map the ZIO failure to [[io.opentelemetry.api.trace.StatusCode]] and [[java.lang.Throwable]].
    *   The latter is used to record the exception, see:
-   *   [[https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/exceptions.md#recording-an-exception]]u
+   *   [[https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/exceptions.md#recording-an-exception]]
    * @tparam E
    */
-  final case class Failure[-E](pf: PartialFunction[E, Result.Failure]) extends Default[E, Any](failure = pf)
+  final case class Failure[-E](pf: PartialFunction[Cause[E], Result.Failure]) extends Default[E, Any](failure = pf)
 
   /**
    * The equivalent of bi-map for StatusMapper.
@@ -165,8 +165,12 @@ object StatusMapper {
   def both[E, A](success: Success[A], failure: Failure[E]): Both[E, A] =
     Both(success, failure)
 
+  private def failureFromZIOFailure[E](e: E => Result.Failure): Failure[E] =
+    Failure(Function.unlift(cause => cause.failureOption.map(e)))
+
   /**
-   * Overrides the status code, description, and exception for a failure case.
+   * Overrides the status code, description, and exception for a failure case stemming from an (expected) effect
+   * failure.
    *
    * Usage example:
    * {{{
@@ -181,10 +185,28 @@ object StatusMapper {
   def failure[E](toStatusCode: E => StatusCode)(toDescription: E => Option[String])(
     toException: E => Option[Throwable]
   ): Failure[E] =
+    failureFromZIOFailure(e => Result.Failure(toStatusCode(e), toDescription(e), toException(e)))
+
+  /**
+   * Overrides the status code, description, and exception for a failure case stemming from any effect error.
+   *
+   * Usage example:
+   * {{{
+   *   StatusMapper.failure[MyError](_ => StatusCode.ERROR)(e => e.failureOption.map(e.message))(e => e.failureOption.map(e => new RuntimeException(e.message)))
+   * }}}
+   *
+   * @param toStatusCode
+   * @param toDescription
+   * @param toException
+   * @return
+   */
+  def failureCause[E](toStatusCode: Cause[E] => StatusCode)(toDescription: Cause[E] => Option[String])(
+    toException: Cause[E] => Option[Throwable]
+  ): Failure[E] =
     Failure { case e => Result.Failure(toStatusCode(e), toDescription(e), toException(e)) }
 
   /**
-   * Overrides the status code and exception for a failure case.
+   * Overrides the status code and exception for a failure case stemming from an (expected) effect failure.
    *
    * Usage example:
    * {{{
@@ -196,10 +218,28 @@ object StatusMapper {
    * @return
    */
   def failureNoDescription[E](toStatusCode: E => StatusCode)(toException: E => Option[Throwable]): Failure[E] =
+    failureFromZIOFailure(e => Result.Failure(toStatusCode(e), exception = toException(e)))
+
+  /**
+   * Overrides the status code and exception for a failure case stemming from any effect error.
+   *
+   * Usage example:
+   * {{{
+   *   StatusMapper.failureNoDescription[MyError](_ => StatusCode.ERROR)(e => e.failureOption.map(e => new RuntimeException(e.message))))
+   * }}}
+   *
+   * @param toStatusCode
+   * @param toException
+   * @return
+   */
+  def failureCauseNoDescription[E](toStatusCode: Cause[E] => StatusCode)(
+    toException: Cause[E] => Option[Throwable]
+  ): Failure[E] =
     Failure { case e => Result.Failure(toStatusCode(e), exception = toException(e)) }
 
   /**
-   * Overrides the status code and description, but skips exception for a failure case.
+   * Overrides the status code and description, but skips exception for a failure case stemming from an (expected)
+   * effect failure.
    *
    * Usage example:
    * {{{
@@ -210,10 +250,26 @@ object StatusMapper {
    * @return
    */
   def failureNoException[E](toStatusCode: E => StatusCode)(toDescription: E => Option[String]): Failure[E] =
+    failureFromZIOFailure(e => Result.Failure(toStatusCode(e), description = toDescription(e)))
+
+  /**
+   * Overrides the status code and description, but skips exception for any effect error.
+   *
+   * Usage example:
+   * {{{
+   *   StatusMapper.failureNoException[MyError](_ => StatusCode.ERROR)(e => e.failureOption(e => e.message)))
+   * }}}
+   *
+   * @param toStatusCode
+   * @return
+   */
+  def failureCauseNoException[E](toStatusCode: Cause[E] => StatusCode)(
+    toDescription: Cause[E] => Option[String]
+  ): Failure[E] =
     Failure { case e => Result.Failure(toStatusCode(e), description = toDescription(e)) }
 
   /**
-   * Overrides the status code and adds an exception for a failure case.
+   * Overrides the status code and adds an exception for a failure case stemming from an (expected) effect failure.
    *
    * Usage example:
    * {{{
@@ -224,7 +280,7 @@ object StatusMapper {
    * @return
    */
   def failureThrowable(toStatusCode: Throwable => StatusCode): Failure[Throwable] =
-    Failure { case e => Result.Failure(toStatusCode(e), None, Option(e)) }
+    failureFromZIOFailure(e => Result.Failure(toStatusCode(e), None, Option(e)))
 
   /**
    * Overrides the status code and description for a success case.

--- a/modules/opentelemetry/main/src/test/scala/zio/telemetry/opentelemetry/core/trace/TracerTest.scala
+++ b/modules/opentelemetry/main/src/test/scala/zio/telemetry/opentelemetry/core/trace/TracerTest.scala
@@ -460,7 +460,9 @@ object TracerTest extends ZIOSpecDefault {
           assert(okNoDescription)(isSome(assertOkNoDescription)) &&
           assert(error)(isSome(assertError))
       },
-      test("failure && failureNoException && failureNoDescription") {
+      test(
+        "failure && failureNoException && failureNoDescription && failureCause && failureCauseNoException && failureCauseNoDescription"
+      ) {
         val assertOkStatusCode     = assertSpanStatusCode(equalTo(StatusCode.OK))
         val assertOkDescription    = assertSpanDescription(equalTo(""))
         val assertOkExceptionEmpty = assertSpanException(isEmpty)
@@ -475,17 +477,33 @@ object TracerTest extends ZIOSpecDefault {
         val assertErrorException        = assertSpanException(
           hasSubset(List("exception.message" -> "Error", "exception.type" -> "java.lang.RuntimeException"))
         )
+        val assertErrorFiberFailure     = assertSpanException(
+          hasSubset(List("exception.message" -> "Error(Error)", "exception.type" -> "zio.FiberFailure"))
+        )
+        val assertBoomRuntimeException  = assertSpanException(
+          hasSubset(List("exception.message" -> "boom", "exception.type" -> "java.lang.RuntimeException"))
+        )
 
-        val assertOkNoException               =
+        val assertOkNoException                 =
           assertOkStatusCode && assertOkDescription && assertOkExceptionEmpty
-        val assertOkNoExceptionAndDescription =
+        val assertOkNoExceptionAndDescription   =
           assertOkStatusCode && assertOkDescription && assertOkExceptionEmpty
-        val assertOkWithException             =
+        val assertOkWithException               =
           assertOkStatusCode && assertOkDescription && assertOkExceptionIsSet
-        val assertErrorNoException            =
+        val assertErrorNoException              =
           assertErrorStatusCode && assertErrorExceptionEmpty && assertErrorDescription
-        val assertErrorNoDescription          =
+        val assertErrorNoExceptionNoDescription =
+          assertErrorStatusCode && assertErrorExceptionEmpty && assertErrorDescriptionEmpty
+        val assertErrorNoDescription            =
           assertErrorStatusCode && assertErrorException && assertErrorDescriptionEmpty
+        val assertErrorCause                    =
+          assertErrorStatusCode && assertErrorFiberFailure && assertErrorDescription
+        val assertErrorCauseNoException         =
+          assertErrorStatusCode && assertErrorExceptionEmpty && assertErrorDescription
+        val assertErrorCauseNoDescription       =
+          assertErrorStatusCode && assertErrorFiberFailure && assertErrorDescriptionEmpty
+        val assertErrorRuntimeBoom              =
+          assertErrorStatusCode && assertBoomRuntimeException && assertErrorDescription
 
         final case class Error(message: String)
 
@@ -544,6 +562,43 @@ object TracerTest extends ZIOSpecDefault {
                   Some(new RuntimeException(e.message))
                 )
               )).either
+          _ <-
+            (ZIO.fail(Error("Error")) @@
+              tracer.aspects.span(
+                "error-cause",
+                statusMapper = StatusMapper.failureCause[Error](_ => StatusCode.ERROR)(_ => Some("Error"))(e =>
+                  Some(FiberFailure(e))
+                )
+              )).either
+          _ <-
+            (ZIO.fail(Error("Error")) @@
+              tracer.aspects.span(
+                "error-cause-no-exception",
+                statusMapper = StatusMapper.failureCauseNoException[Error](_ => StatusCode.ERROR)(_ => Some("Error"))
+              )).either
+          _ <-
+            (ZIO.fail(Error("Error")) @@
+              tracer.aspects.span(
+                "error-cause-no-description",
+                statusMapper =
+                  StatusMapper.failureCauseNoDescription[Error](_ => StatusCode.ERROR)(e => Some(FiberFailure(e)))
+              )).either
+          _ <-
+            (ZIO.die(new RuntimeException("boom")) @@
+              tracer.aspects.span(
+                "error-die",
+                statusMapper = StatusMapper.failure[Error](_ => StatusCode.ERROR)(_ => Some("Error"))(e =>
+                  Some(new RuntimeException(e.message))
+                )
+              )).sandbox.ignore
+          _ <-
+            (ZIO.die(new RuntimeException("boom")) @@
+              tracer.aspects.span(
+                "error-cause-die",
+                statusMapper = StatusMapper.failureCause[Error](_ => StatusCode.ERROR)(_ => Some("Error"))(e =>
+                  Some(new RuntimeException(FiberFailure(e).getMessage()))
+                )
+              )).sandbox.ignore
 
           spans                      <- tracerTestkit.getFinishedSpans
           okNoException               = spans.find(_.name == "ok-no-exception")
@@ -553,13 +608,24 @@ object TracerTest extends ZIOSpecDefault {
           errorNoException            = spans.find(_.name == "error-no-exception")
           errorNoDescription          = spans.find(_.name == "error-no-description")
           errorNoDescription1         = spans.find(_.name == "error-no-description-1")
+          errorCause                  = spans.find(_.name == "error-cause")
+          errorCauseNoException       = spans.find(_.name == "error-cause-no-exception")
+          errorCauseNoDescription     = spans.find(_.name == "error-cause-no-description")
+          errorDie                    = spans.find(_.name == "error-die")
+          errorCauseDie               = spans.find(_.name == "error-cause-die")
         } yield assert(okNoException)(isSome(assertOkNoException)) &&
           assert(okNoException1)(isSome(assertOkNoException)) &&
           assert(okNoExceptionAndDescription)(isSome(assertOkNoExceptionAndDescription)) &&
           assert(okWithException)(isSome(assertOkWithException)) &&
           assert(errorNoException)(isSome(assertErrorNoException)) &&
           assert(errorNoDescription)(isSome(assertErrorNoDescription)) &&
-          assert(errorNoDescription1)(isSome(assertErrorNoDescription))
+          assert(errorNoDescription1)(isSome(assertErrorNoDescription)) &&
+          assert(errorCause)(isSome(assertErrorCause)) &&
+          assert(errorCauseNoException)(isSome(assertErrorCauseNoException)) &&
+          assert(errorCauseNoDescription)(isSome(assertErrorCauseNoDescription)) &&
+          // the non-cause version doesn't set exception nor description for defects
+          assert(errorDie)(isSome(assertErrorNoExceptionNoDescription)) &&
+          assert(errorCauseDie)(isSome(assertErrorRuntimeBoom))
       },
       test("failureThrowable") {
         val assertOkStatusCode  = assertSpanStatusCode(equalTo(StatusCode.OK))


### PR DESCRIPTION
when using the `StatusMapper` API, there was previously no way to record exceptions for defects (or extract stack traces from failures, unless the failure was itself a throwable); it had to be done via an explicit `recordException` using something like this: `.tapErrorCause(e => span.recordException(...))`

additionally, it was impossible to set a description based on a defect, because even if you explicitly call `span.setStatus(status, description)`, the `StatusMapper` would overwrite the description (with `""`) when the span ends.

for more discussion, see [this thread on Discord](https://discord.com/channels/629491597070827530/639825316021272602/1526684761098158131)