### PR TITLE
feat: configure default `StatusMapper` when creating `Tracer`

### DIFF
--- a/modules/opentelemetry/core/src/main/scala/zio/telemetry/opentelemetry/core/trace/StatusMapper.scala
+++ b/modules/opentelemetry/core/src/main/scala/zio/telemetry/opentelemetry/core/trace/StatusMapper.scala
@@ -141,11 +141,17 @@ object StatusMapper {
     new Empty
 
   /**
-   * It follows the offical specification:
+   * It follows the official specification:
    * [[https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status Set status]]
    */
   val default: Default[Any, Any] =
     new Default()
+
+  /**
+   * Same as [[default]] above, but also sets exception stack traces
+   */
+  val defaultRecordingExceptions: Failure[Any] =
+    StatusMapper.failureCauseNoDescription[Any](_ => StatusCode.ERROR)(c => Some(FiberFailure(c)))
 
   /**
    * Overrides both success and failure cases of the default status mapper.

--- a/modules/opentelemetry/core/src/main/scala/zio/telemetry/opentelemetry/core/trace/Tracer.scala
+++ b/modules/opentelemetry/core/src/main/scala/zio/telemetry/opentelemetry/core/trace/Tracer.scala
@@ -11,6 +11,8 @@ import scala.concurrent.ExecutionContext
 
 trait Tracer { self =>
 
+  protected val defaultStatusMapper: StatusMapper[Any, Any]
+
   /**
    * Sets the new span to be the new root span with name 'spanName'.
    *
@@ -36,7 +38,7 @@ trait Tracer { self =>
     spanName: String,
     spanKind: SpanKind = SpanKind.SERVER,
     attributes: Attributes = Attributes.empty(),
-    statusMapper: StatusMapper[E, A] = StatusMapper.default,
+    statusMapper: StatusMapper[E, A] = defaultStatusMapper,
     links: Seq[SpanContext] = Seq.empty
   )(f: Span => ZIO[R, E1, A1])(implicit trace: Trace): ZIO[R, E1, A1]
 
@@ -65,7 +67,7 @@ trait Tracer { self =>
     spanName: String,
     spanKind: SpanKind = SpanKind.INTERNAL,
     attributes: Attributes = Attributes.empty(),
-    statusMapper: StatusMapper[E, A] = StatusMapper.default,
+    statusMapper: StatusMapper[E, A] = defaultStatusMapper,
     links: Seq[SpanContext] = Seq.empty
   )(f: Span => ZIO[R, E1, A1])(implicit trace: Trace): ZIO[R, E1, A1]
 
@@ -87,7 +89,7 @@ trait Tracer { self =>
     spanName: String,
     spanKind: SpanKind = SpanKind.INTERNAL,
     attributes: Attributes = Attributes.empty(),
-    statusMapper: StatusMapper[E, A] = StatusMapper.default,
+    statusMapper: StatusMapper[E, A] = defaultStatusMapper,
     links: Seq[SpanContext] = Seq.empty
   )(implicit trace: Trace): ZIO[Scope, Nothing, Span]
 
@@ -154,7 +156,7 @@ trait Tracer { self =>
     spanName: String,
     spanKind: SpanKind = SpanKind.INTERNAL,
     attributes: Attributes = Attributes.empty(),
-    statusMapper: StatusMapper[E, A] = StatusMapper.default,
+    statusMapper: StatusMapper[E, A] = defaultStatusMapper,
     links: Seq[SpanContext] = Seq.empty
   )(f: Span => ZIO[R, E1, A1])(implicit trace: Trace): ZIO[R, E1, A1]
 
@@ -215,7 +217,7 @@ trait Tracer { self =>
       spanName: String,
       spanKind: SpanKind = SpanKind.SERVER,
       attributes: Attributes = Attributes.empty(),
-      statusMapper: StatusMapper[E1, A1] = StatusMapper.default,
+      statusMapper: StatusMapper[E1, A1] = defaultStatusMapper,
       links: Seq[SpanContext] = Seq.empty
     ): ZIOAspect[Nothing, Any, Nothing, E1, Nothing, A1] =
       new ZIOAspect[Nothing, Any, Nothing, E1, Nothing, A1] {
@@ -227,7 +229,7 @@ trait Tracer { self =>
       spanName: String,
       spanKind: SpanKind = SpanKind.INTERNAL,
       attributes: Attributes = Attributes.empty(),
-      statusMapper: StatusMapper[E1, A1] = StatusMapper.default,
+      statusMapper: StatusMapper[E1, A1] = defaultStatusMapper,
       links: Seq[SpanContext] = Seq.empty
     ): ZIOAspect[Nothing, Any, Nothing, E1, Nothing, A1] =
       new ZIOAspect[Nothing, Any, Nothing, E1, Nothing, A1] {
@@ -240,7 +242,7 @@ trait Tracer { self =>
       spanName: String,
       spanKind: SpanKind = SpanKind.INTERNAL,
       attributes: Attributes = Attributes.empty(),
-      statusMapper: StatusMapper[E1, A1] = StatusMapper.default,
+      statusMapper: StatusMapper[E1, A1] = defaultStatusMapper,
       links: Seq[SpanContext] = Seq.empty
     ): ZIOAspect[Nothing, Any, Nothing, E1, Nothing, A1] =
       new ZIOAspect[Nothing, Any, Nothing, E1, Nothing, A1] {
@@ -254,13 +256,20 @@ trait Tracer { self =>
 
 private[opentelemetry] object Tracer {
 
-  def make(tracer: JTracer, ctxStorage: ContextStorage, logAnnotated: Boolean = false): Tracer =
+  def make(
+    tracer: JTracer,
+    ctxStorage: ContextStorage,
+    logAnnotated: Boolean = false,
+    statusMapper: StatusMapper[Any, Any] = StatusMapper.default
+  ): Tracer =
     new Tracer { self =>
+      override protected val defaultStatusMapper: StatusMapper[Any, Any] = statusMapper
+
       override def root[R, E, E1 <: E, A, A1 <: A](
         spanName: String,
         spanKind: SpanKind = SpanKind.SERVER,
         attributes: Attributes = Attributes.empty(),
-        statusMapper: StatusMapper[E, A] = StatusMapper.default,
+        statusMapper: StatusMapper[E, A] = defaultStatusMapper,
         links: Seq[SpanContext] = Seq.empty
       )(f: Span => ZIO[R, E1, A1])(implicit trace: Trace): ZIO[R, E1, A1] =
         ZIO.acquireReleaseWith {
@@ -275,7 +284,7 @@ private[opentelemetry] object Tracer {
         spanName: String,
         spanKind: SpanKind = SpanKind.INTERNAL,
         attributes: Attributes = Attributes.empty(),
-        statusMapper: StatusMapper[E, A] = StatusMapper.default,
+        statusMapper: StatusMapper[E, A] = defaultStatusMapper,
         links: Seq[SpanContext] = Seq.empty
       )(f: Span => ZIO[R, E1, A1])(implicit trace: Trace): ZIO[R, E1, A1] =
         for {
@@ -293,7 +302,7 @@ private[opentelemetry] object Tracer {
         spanName: String,
         spanKind: SpanKind = SpanKind.INTERNAL,
         attributes: Attributes,
-        statusMapper: StatusMapper[E, A] = StatusMapper.default,
+        statusMapper: StatusMapper[E, A] = defaultStatusMapper,
         links: Seq[SpanContext]
       )(implicit trace: Trace): ZIO[Scope, Nothing, Span] =
         for {
@@ -325,7 +334,7 @@ private[opentelemetry] object Tracer {
         spanName: String,
         spanKind: SpanKind = SpanKind.INTERNAL,
         attributes: Attributes = Attributes.empty(),
-        statusMapper: StatusMapper[E, A] = StatusMapper.default,
+        statusMapper: StatusMapper[E, A] = defaultStatusMapper,
         links: Seq[SpanContext] = Seq.empty
       )(f: Span => ZIO[R, E1, A1])(implicit trace: Trace): ZIO[R, E1, A1] =
         ZIO.acquireReleaseWith {

--- a/modules/opentelemetry/main/src/main/scala/zio/telemetry/opentelemetry/OpenTelemetry.scala
+++ b/modules/opentelemetry/main/src/main/scala/zio/telemetry/opentelemetry/OpenTelemetry.scala
@@ -8,7 +8,7 @@ import zio.telemetry.opentelemetry.core.context.internal.ContextStorage
 import zio.telemetry.opentelemetry.core.logs.Logger
 import zio.telemetry.opentelemetry.core.metrics.Meter
 import zio.telemetry.opentelemetry.core.metrics.internal.{Instrument, InstrumentRegistry, OtelMetricListener}
-import zio.telemetry.opentelemetry.core.trace.Tracer
+import zio.telemetry.opentelemetry.core.trace.{StatusMapper, Tracer}
 
 /**
  * The entrypoint to telemetry functionality for tracer, metrics, logger and baggage.
@@ -82,7 +82,8 @@ object OpenTelemetry {
     instrumentationScopeName: String,
     instrumentationVersion: Option[String] = None,
     schemaUrl: Option[String] = None,
-    logAnnotated: Boolean = false
+    logAnnotated: Boolean = false,
+    statusMapper: StatusMapper[Any, Any] = StatusMapper.default
   )(implicit trace: Trace): URLayer[core.OpenTelemetry, Tracer] = {
     def buildTracer(openTelemetry: JOpenTelemetry) = {
       val builder = openTelemetry.tracerBuilder(instrumentationScopeName)
@@ -97,7 +98,7 @@ object OpenTelemetry {
       for {
         openTelemetry <- ZIO.service[core.OpenTelemetry]
         jtracer        = buildTracer(openTelemetry.unsafe.asJava)
-        tracer         = Tracer.make(jtracer, openTelemetry.unsafe.getCtxStorage, logAnnotated)
+        tracer         = Tracer.make(jtracer, openTelemetry.unsafe.getCtxStorage, logAnnotated, statusMapper)
       } yield tracer
     }
   }

--- a/modules/opentelemetry/main/src/test/scala/zio/telemetry/opentelemetry/core/trace/TracerTest.scala
+++ b/modules/opentelemetry/main/src/test/scala/zio/telemetry/opentelemetry/core/trace/TracerTest.scala
@@ -378,18 +378,54 @@ object TracerTest extends ZIOSpecDefault {
         val assertDefaultFailed =
           assertFailedStatusCode && assertFailedDescription
 
+        val assertErrorExceptionEmpty = assertSpanException(isEmpty)
+
         for {
           tracerTestkit <- ZIO.service[TracerTestkit]
-          tracer        <- tracerTestkit.getTracer(instrumentationScopeName)
-          _             <- ZIO.unit @@ tracer.aspects.span("default-ok", statusMapper = StatusMapper.default)
+          tracer        <- tracerTestkit.getTracer(instrumentationScopeName, statusMapper = StatusMapper.default)
+          _             <- ZIO.unit @@ tracer.aspects.span("default-ok")
           _             <- (
                              ZIO.fail(new RuntimeException("Error")) @@
-                               tracer.aspects.span("default-failed", statusMapper = StatusMapper.default)
+                               tracer.aspects.span("default-failed")
                            ).either
           spans         <- tracerTestkit.getFinishedSpans
           defaultOk      = spans.find(_.name == "default-ok")
           defaultFailed  = spans.find(_.name == "default-failed")
-        } yield assert(defaultOk)(isSome(assertDefaultOk)) && assert(defaultFailed)(isSome(assertDefaultFailed))
+        } yield assert(defaultOk)(isSome(assertDefaultOk)) && assert(defaultFailed)(
+          isSome(assertDefaultFailed && assertErrorExceptionEmpty)
+        )
+      },
+      test("defaultRecordingExceptions") {
+        val assertOkStatusCode  = assertSpanStatusCode(equalTo(StatusCode.UNSET))
+        val assertOkDescription = assertSpanDescription(equalTo(""))
+
+        val assertFailedStatusCode  = assertSpanStatusCode(equalTo(StatusCode.ERROR))
+        val assertFailedDescription = assertSpanDescription(equalTo(""))
+
+        val assertDefaultOk     =
+          assertOkStatusCode && assertOkDescription
+        val assertDefaultFailed =
+          assertFailedStatusCode && assertFailedDescription
+
+        val assertErrorRuntimeException = assertSpanException(
+          hasSubset(List("exception.message" -> "Error", "exception.type" -> "zio.FiberFailure"))
+        )
+
+        for {
+          tracerTestkit <- ZIO.service[TracerTestkit]
+          tracer        <-
+            tracerTestkit.getTracer(instrumentationScopeName, statusMapper = StatusMapper.defaultRecordingExceptions)
+          _             <- ZIO.unit @@ tracer.aspects.span("default-ok")
+          _             <- (
+                             ZIO.fail(new RuntimeException("Error")) @@
+                               tracer.aspects.span("default-failed")
+                           ).either
+          spans         <- tracerTestkit.getFinishedSpans
+          defaultOk      = spans.find(_.name == "default-ok")
+          defaultFailed  = spans.find(_.name == "default-failed")
+        } yield assert(defaultOk)(isSome(assertDefaultOk)) && assert(defaultFailed)(
+          isSome(assertDefaultFailed && assertErrorRuntimeException)
+        )
       },
       test("both") {
         val assertDefaultOkStatusCode  = assertSpanStatusCode(equalTo(StatusCode.UNSET))

--- a/modules/opentelemetry/testkit/src/main/scala/zio/telemetry/opentelemetry/testkit/trace/TracerTestkit.scala
+++ b/modules/opentelemetry/testkit/src/main/scala/zio/telemetry/opentelemetry/testkit/trace/TracerTestkit.scala
@@ -6,7 +6,7 @@ import io.opentelemetry.sdk.trace.SdkTracerProvider
 import io.opentelemetry.sdk.trace.`export`.SimpleSpanProcessor
 import zio._
 import zio.telemetry.opentelemetry.core.context.internal.ContextStorage
-import zio.telemetry.opentelemetry.core.trace.Tracer
+import zio.telemetry.opentelemetry.core.trace.{StatusMapper, Tracer}
 
 import scala.jdk.CollectionConverters._
 
@@ -20,7 +20,8 @@ trait TracerTestkit {
     instrumentationScopeName: String,
     instrumentationVersion: Option[String] = None,
     schemaUrl: Option[String] = None,
-    logAnnotated: Boolean = false
+    logAnnotated: Boolean = false,
+    statusMapper: StatusMapper[Any, Any] = StatusMapper.default
   )(implicit trace: Trace): Task[Tracer]
 
   trait UnsafeAPI {
@@ -31,7 +32,11 @@ trait TracerTestkit {
       schemaUrl: Option[String] = None
     )(implicit trace: Trace): Task[JTracer]
 
-    def getTracerFromJava(jtracer: JTracer, logAnnotated: Boolean = false): Task[Tracer]
+    def getTracerFromJava(
+      jtracer: JTracer,
+      logAnnotated: Boolean = false,
+      statusMapper: StatusMapper[Any, Any] = StatusMapper.default
+    ): Task[Tracer]
 
     def getTracerProvider: SdkTracerProvider
 
@@ -68,8 +73,12 @@ object TracerTestkit {
               builder.build
             }
 
-            override def getTracerFromJava(jtracer: JTracer, logAnnotated: Boolean = false): Task[Tracer] =
-              ZIO.succeed(Tracer.make(jtracer, ctxStorage, logAnnotated))
+            override def getTracerFromJava(
+              jtracer: JTracer,
+              logAnnotated: Boolean = false,
+              statusMapper: StatusMapper[Any, Any] = StatusMapper.default
+            ): Task[Tracer] =
+              ZIO.succeed(Tracer.make(jtracer, ctxStorage, logAnnotated, statusMapper))
 
             override def getTracerProvider: SdkTracerProvider =
               tracerProvider
@@ -89,11 +98,12 @@ object TracerTestkit {
           instrumentationScopeName: String,
           instrumentationVersion: Option[String] = None,
           schemaUrl: Option[String] = None,
-          logAnnotated: Boolean = false
+          logAnnotated: Boolean = false,
+          statusMapper: StatusMapper[Any, Any] = StatusMapper.default
         )(implicit trace: Trace): Task[Tracer] =
           for {
             jtracer <- unsafe.getTracer(instrumentationScopeName, instrumentationVersion, schemaUrl)
-            tracer  <- unsafe.getTracerFromJava(jtracer, logAnnotated)
+            tracer  <- unsafe.getTracerFromJava(jtracer, logAnnotated, statusMapper)
           } yield tracer
 
       }


### PR DESCRIPTION
The default behavior sets `ERROR` status for spans, but omits exception traces. This makes it difficult to debug issues. 
This PR aims to make it easy to configure the default behavior.

see more discussion here: https://discord.com/channels/629491597070827530/639825316021272602/1526684761098158131

follow-up to https://github.com/zio/zio-telemetry/pull/1215