### PR TITLE
refactor: remove duplicated default arguments from Tracing implementations

### DIFF
--- a/opencensus/src/main/scala/zio/telemetry/opencensus/Tracing.scala
+++ b/opencensus/src/main/scala/zio/telemetry/opencensus/Tracing.scala
@@ -119,9 +119,9 @@ object Tracing {
 
         override def span[R, E, E1 <: E, A](
           name: String,
-          kind: Span.Kind = Span.Kind.SERVER,
-          toErrorStatus: ErrorMapper[E] = ErrorMapper.default,
-          attributes: Map[String, AttributeValue] = Map.empty
+          kind: Span.Kind,
+          toErrorStatus: ErrorMapper[E],
+          attributes: Map[String, AttributeValue]
         )(zio: => ZIO[R, E1, A])(implicit trace: Trace): ZIO[R, E1, A] =
           ZIO.scoped[R] {
             for {
@@ -133,9 +133,9 @@ object Tracing {
 
         override def root[R, E, E1 <: E, A](
           name: String,
-          kind: Span.Kind = Span.Kind.SERVER,
-          toErrorStatus: ErrorMapper[E] = ErrorMapper.default,
-          attributes: Map[String, AttributeValue] = Map.empty
+          kind: Span.Kind,
+          toErrorStatus: ErrorMapper[E],
+          attributes: Map[String, AttributeValue]
         )(zio: => ZIO[R, E1, A])(implicit trace: Trace): ZIO[R, E1, A] =
           ZIO.scoped[R] {
             createSpan(BlankSpan.INSTANCE, name, kind).flatMap { span =>
@@ -148,9 +148,9 @@ object Tracing {
         override def fromRemoteSpan[R, E, E1 <: E, A](
           remote: SpanContext,
           name: String,
-          kind: Span.Kind = Span.Kind.SERVER,
-          toErrorStatus: ErrorMapper[E] = ErrorMapper.default,
-          attributes: Map[String, AttributeValue] = Map.empty
+          kind: Span.Kind,
+          toErrorStatus: ErrorMapper[E],
+          attributes: Map[String, AttributeValue]
         )(zio: => ZIO[R, E1, A])(implicit trace: Trace): ZIO[R, E1, A] =
           ZIO.scoped[R] {
             createSpanFromRemote(remote, name, kind).flatMap { span =>
@@ -165,9 +165,9 @@ object Tracing {
           carrier: C,
           getter: TextFormat.Getter[C],
           name: String,
-          kind: Span.Kind = Span.Kind.SERVER,
-          toErrorStatus: ErrorMapper[E] = ErrorMapper.default,
-          attributes: Map[String, AttributeValue] = Map.empty
+          kind: Span.Kind,
+          toErrorStatus: ErrorMapper[E],
+          attributes: Map[String, AttributeValue]
         )(zio: => ZIO[R, E1, A])(implicit trace: Trace): ZIO[R, E1, A] =
           ZIO
             .attempt(format.extract(carrier, getter))

--- a/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/tracing/Tracing.scala
+++ b/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/tracing/Tracing.scala
@@ -542,10 +542,10 @@ object Tracing {
             propagator: TraceContextPropagator,
             carrier: IncomingContextCarrier[C],
             spanName: String,
-            spanKind: SpanKind = SpanKind.INTERNAL,
-            attributes: Attributes = Attributes.empty(),
-            statusMapper: StatusMapper[E, A] = StatusMapper.default,
-            links: Seq[SpanContext] = Seq.empty
+            spanKind: SpanKind,
+            attributes: Attributes,
+            statusMapper: StatusMapper[E, A],
+            links: Seq[SpanContext]
           )(zio: => ZIO[R, E1, A1])(implicit trace: Trace): ZIO[R, E1, A1] =
             extractContext(propagator, carrier).flatMap { context =>
               ZIO.acquireReleaseWith {
@@ -561,9 +561,9 @@ object Tracing {
             propagator: TraceContextPropagator,
             carrier: IncomingContextCarrier[C],
             spanName: String,
-            spanKind: SpanKind = SpanKind.INTERNAL,
-            attributes: Attributes = Attributes.empty(),
-            links: Seq[SpanContext] = Seq.empty
+            spanKind: SpanKind,
+            attributes: Attributes,
+            links: Seq[SpanContext]
           )(implicit trace: Trace): UIO[(Span, UIO[Any])] =
             for {
               ctx        <- extractContext(propagator, carrier)
@@ -575,10 +575,10 @@ object Tracing {
 
           override def root[R, E, E1 <: E, A, A1 <: A](
             spanName: String,
-            spanKind: SpanKind = SpanKind.INTERNAL,
-            attributes: Attributes = Attributes.empty(),
-            statusMapper: StatusMapper[E, A] = StatusMapper.default,
-            links: Seq[SpanContext] = Seq.empty
+            spanKind: SpanKind,
+            attributes: Attributes,
+            statusMapper: StatusMapper[E, A],
+            links: Seq[SpanContext]
           )(zio: => ZIO[R, E1, A1])(implicit trace: Trace): ZIO[R, E1, A1] =
             ZIO.acquireReleaseWith {
               createRoot(spanName, spanKind, attributes, links)
@@ -590,10 +590,10 @@ object Tracing {
 
           override def span[R, E, E1 <: E, A, A1 <: A](
             spanName: String,
-            spanKind: SpanKind = SpanKind.INTERNAL,
-            attributes: Attributes = Attributes.empty(),
-            statusMapper: StatusMapper[E, A] = StatusMapper.default,
-            links: Seq[SpanContext] = Seq.empty
+            spanKind: SpanKind,
+            attributes: Attributes,
+            statusMapper: StatusMapper[E, A],
+            links: Seq[SpanContext]
           )(zio: => ZIO[R, E1, A1])(implicit trace: Trace): ZIO[R, E1, A1] =
             getCurrentContextUnsafe.flatMap { old =>
               ZIO.acquireReleaseWith {
@@ -609,7 +609,7 @@ object Tracing {
             spanName: String,
             spanKind: SpanKind,
             attributes: Attributes,
-            statusMapper: StatusMapper[Any, Unit] = StatusMapper.default,
+            statusMapper: StatusMapper[Any, Unit],
             links: Seq[SpanContext]
           )(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
             getCurrentContextUnsafe.flatMap { old =>
@@ -631,9 +631,9 @@ object Tracing {
 
           override def spanUnsafe(
             spanName: String,
-            spanKind: SpanKind = SpanKind.INTERNAL,
-            attributes: Attributes = Attributes.empty(),
-            links: Seq[SpanContext] = Seq.empty
+            spanKind: SpanKind,
+            attributes: Attributes,
+            links: Seq[SpanContext]
           )(implicit trace: Trace): UIO[(Span, UIO[Any])] =
             for {
               ctx        <- getCurrentContextUnsafe
@@ -687,10 +687,10 @@ object Tracing {
           override def inSpan[R, E, E1 <: E, A, A1 <: A](
             span: Span,
             spanName: String,
-            spanKind: SpanKind = SpanKind.INTERNAL,
-            attributes: Attributes = Attributes.empty(),
-            statusMapper: StatusMapper[E, A] = StatusMapper.default,
-            links: Seq[SpanContext] = Seq.empty
+            spanKind: SpanKind,
+            attributes: Attributes,
+            statusMapper: StatusMapper[E, A],
+            links: Seq[SpanContext]
           )(zio: => ZIO[R, E1, A1])(implicit trace: Trace): ZIO[R, E1, A1] =
             ZIO.acquireReleaseWith {
               createChild(Context.root().`with`(span), spanName, spanKind, attributes, links)


### PR DESCRIPTION
## What

Default argument values were declared twice — once on the `Tracing` trait, once again on the anonymous implementation inside `Tracing.scoped` — in both the `opentelemetry` and `opencensus` modules. This removes the second copy: 23 duplicated defaults in `opentelemetry/.../tracing/Tracing.scala` and 12 in `opencensus/.../Tracing.scala`.

Reported by @dontgitit on [Discord](https://discord.com/channels/629491597070827530/639825316021272602/1539740044858892339).

## Why

Two reasons beyond DRY.

**1. The copies are unnecessary.** An override that omits defaults inherits them from the overridden method. The compiler attaches the synthetic default getters (`span$default$2` and friends) to `Tracing` itself, so callers keep working whether they hold the trait type or the concrete one.

**2. Duplicated defaults are a silent hazard.** Those getters are ordinary virtual methods, so an implementation's default *overrides* the trait's — even for callers typed as the trait:

```scala
trait T { def g(x: Int = 1): Int }
object Impl extends T { override def g(x: Int = 99): Int = x }

val t: T = Impl
t.g() // 99, not 1
```

If the copies ever drift, the trait's documented default becomes a lie and nothing fails to compile. `spanScoped` had already half-drifted — four parameters, only `statusMapper` still carrying a default — which is exactly the accident this prevents.

Minor bonus: fewer synthetic `$default$n` definitions on the implementations.

Left alone deliberately: defaults on factory methods (`Tracing.live`, `Tracing.scoped`) and on the concrete `aspects.*` helpers. Those are the API surface, not overrides.

## Compatibility

Source-compatible: the trait defaults are untouched, and the anonymous classes are unnameable by users — `live`/`scoped` return `Tracing`.

Binary-compatible: verified against the compiled 2.13 output. The anon impl class still exposes all 26 `$default$n` getters, now as mixin forwarders to the trait defaults. `javap` member dumps before and after the change are byte-for-byte identical.

No behavior change: every removed default was value-identical to its trait counterpart (`SpanKind.INTERNAL`, `Attributes.empty()`, `StatusMapper.default`, `Seq.empty`; OpenCensus: `Span.Kind.SERVER`, `ErrorMapper.default`, `Map.empty`).

## Verification

- `+Test/compile` green on 2.12.21, 2.13.18, 3.3.8
- `scalafmtCheckAll` green
- `javap` pre/post member-list diff on `Tracing$$anon$5`: identical

## Note, not addressed here

`project/MimaSettings.scala` currently accepts a `failOnProblem: Boolean` parameter and then ignores it, hardcoding `mimaFailOnProblem := false`, while all four call sites pass `true`. Combined with `exclude[Problem]` filters covering every shipping package, the Mima check cannot fail. Out of scope for this PR, but worth a look.
