### PR TITLE
docs: use @VERSION@ placeholder in installation snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,25 +29,25 @@ ZIO Telemetry is a purely functional client which helps up propagate context bet
 In order to use this library, we need to add the following line in our `build.sbt` file if we want to use [OpenTelemetry](https://opentelemetry.io/) client:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-opentelemetry" % "<version>"
+libraryDependencies += "dev.zio" %% "zio-opentelemetry" % "3.1.19"
 ```
 
 If you're using [ZIO Logging](https://github.com/zio/zio-logging) you can combine OpenTelemetry with ZIO Logging using:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-opentelemetry-zio-logging" % "<version>"
+libraryDependencies += "dev.zio" %% "zio-opentelemetry-zio-logging" % "3.1.19"
 ```
 
 For using [OpenTracing](https://opentracing.io/) client we should add the following line in our `build.sbt` file:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-opentracing" % "<version>"
+libraryDependencies += "dev.zio" %% "zio-opentracing" % "3.1.19"
 ```
 
 And for using [OpenCensus](https://opencensus.io/) client we should add the following line in our `build.sbt` file:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-opencensus" % "<version>"
+libraryDependencies += "dev.zio" %% "zio-opencensus" % "3.1.19"
 ```
 
 ## Examples

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,25 +29,25 @@ ZIO Telemetry is a purely functional client which helps up propagate context bet
 In order to use this library, we need to add the following line in our `build.sbt` file if we want to use [OpenTelemetry](https://opentelemetry.io/) client:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-opentelemetry" % "<version>"
+libraryDependencies += "dev.zio" %% "zio-opentelemetry" % "@VERSION@"
 ```
 
 If you're using [ZIO Logging](https://github.com/zio/zio-logging) you can combine OpenTelemetry with ZIO Logging using:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-opentelemetry-zio-logging" % "<version>"
+libraryDependencies += "dev.zio" %% "zio-opentelemetry-zio-logging" % "@VERSION@"
 ```
 
 For using [OpenTracing](https://opentracing.io/) client we should add the following line in our `build.sbt` file:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-opentracing" % "<version>"
+libraryDependencies += "dev.zio" %% "zio-opentracing" % "@VERSION@"
 ```
 
 And for using [OpenCensus](https://opencensus.io/) client we should add the following line in our `build.sbt` file:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-opencensus" % "<version>"
+libraryDependencies += "dev.zio" %% "zio-opencensus" % "@VERSION@"
 ```
 
 ## Examples

--- a/docs/opencensus.md
+++ b/docs/opencensus.md
@@ -10,7 +10,7 @@ and [Zipkin](https://www.zipkin.io).
 
 First, add the following dependency to your build.sbt:
 ```
-"dev.zio" %% "zio-opencensus" % "<version>"
+"dev.zio" %% "zio-opencensus" % "@VERSION@"
 ```
 
 ## Usage

--- a/docs/opentelemetry-zio-logging.md
+++ b/docs/opentelemetry-zio-logging.md
@@ -12,7 +12,7 @@ In order to use `zio-opentelemetry` feature with `zio-logging` you should use `z
 ## Installation
 
 ```scala
-"dev.zio" %% "zio-opentelemetry-zio-logging" % "<version>"
+"dev.zio" %% "zio-opentelemetry-zio-logging" % "@VERSION@"
 ```
 
 ## Features

--- a/docs/opentelemetry.md
+++ b/docs/opentelemetry.md
@@ -19,7 +19,7 @@ Some of the key features:
 Add the following dependency to your `build.sbt` to use OpenTelemetry inside your ZIO application:
 
 ```scala
-"dev.zio" %% "zio-opentelemetry" % "<version>"
+"dev.zio" %% "zio-opentelemetry" % "@VERSION@"
 ```
 
 You will also need SDK dependencies to be able to provide configured instances of [Tracer](https://javadoc.io/doc/io.opentelemetry/opentelemetry-api/latest/io/opentelemetry/api/trace/Tracer.html), [Meter](https://javadoc.io/static/io.opentelemetry/opentelemetry-api/1.33.0/io/opentelemetry/api/metrics/Meter.html), and [Logger](https://javadoc.io/doc/io.opentelemetry/opentelemetry-api/latest/io/opentelemetry/api/logs/Logger.html), such as:

--- a/docs/opentracing.md
+++ b/docs/opentracing.md
@@ -11,7 +11,7 @@ and logs across process boundaries. Well known implementations are [Jaeger](http
 First, add the following dependency to your build.sbt:
 
 ```
-"dev.zio" %% "zio-opentracing" % "<version>"
+"dev.zio" %% "zio-opentracing" % "@VERSION@"
 ```
 
 ## Usage


### PR DESCRIPTION
The `zio-sbt-website` plugin exposes a `VERSION` mdoc variable that resolves to the latest release tag. The installation snippets in `docs/` used a literal `<version>` string, so the published documentation showed `<version>` instead of a real, copy-pasteable version.

Replacing it with `@VERSION@` lets mdoc substitute the actual version at docs compilation time.

### Changes

- `docs/index.md`, `docs/opentelemetry.md`, `docs/opentracing.md`, `docs/opencensus.md`, `docs/opentelemetry-zio-logging.md`: `<version>` → `@VERSION@`
- `README.md`: regenerated via `sbt docs/generateReadme`

### Verification

- `sbt docs/mdoc` → generated `website/docs/*.md` contain `"dev.zio" %% "zio-opentelemetry" % "3.1.19"`
- `sbt docs/checkReadme` → passes with the regenerated `README.md`