### PR TITLE
chore: ignore generated website/docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ out/
 .vscode
 website/node_modules
 website/build
+website/docs
 website/i18n
 website/static/api
 website/yarn.lock


### PR DESCRIPTION
## Change

Add `website/docs` to `.gitignore`.

Everything under `website/docs/` is build output: `docs/mdoc` compiles the ten files in `docs/` (eight markdown pages plus `package.json` and `sidebars.js`) into `website/docs/`. None of it is edited by hand, and it is regenerated by `docs/mdoc`, `docs/generateReadme`, and the website build.

## Why it matters

`docs/checkReadme` in zio-sbt is `generateReadme` followed by a bare `git diff --exit-code` over the whole worktree, not a README-scoped diff. Since `generateReadme` runs mdoc as part of its task sequence, any regenerated file left visible to git makes `sbt check` fail on build output instead of on a real problem. The directory being untracked-but-not-ignored also makes it easy to sweep the generated files into a commit with `git add -A`.

Note that CI would not catch either case: the Lint job runs only `ciCheckGithubWorkflow` and `lint`, so `docsCheck` is a local-only gate.

## Verification

- `git check-ignore -v` matches all ten generated files against the new rule.
- With `website/docs/` present on disk after an mdoc run, `git status` reports a clean worktree.
- No files are untracked by this change — `website/docs` was never tracked on `series/2.x`.
