### PR TITLE
build: update zio-sbt to 0.7.1

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-val zioSbtVersion = "0.7.0"
+val zioSbtVersion = "0.7.1"
 
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings"          % "3.0.3")
 addSbtPlugin("com.github.sbt"                    % "sbt-unidoc"                % "0.6.1")


### PR DESCRIPTION
## Change

Bump `zioSbtVersion` from `0.7.0` to `0.7.1`.

The only behavioural change in 0.7.1 (zio/zio-sbt#747) is how `zio-sbt-website` picks the npm dist-tag when publishing docs. Previously the tag was derived from the prerelease identifier unconditionally, so `1.0.0-RC27` always published as `rc`. Now a prerelease is sidelined under its own tag **only when a stable release already holds `latest`**.

## Effect here: none, deliberately

`@zio.dev/zio-telemetry` has `3.1.19` on `latest`, which is stable. So prereleases on the 4.x line keep going to the `rc` tag exactly as they do today, and zio.dev keeps documenting the stable release rather than an unreleased API.

That is the case 0.7.1 is careful to preserve. The bump is worth taking anyway: it keeps the plugin current, and it means the behaviour is now guaranteed by an explicit condition rather than being a side effect of the version string containing a dash. If this project ever publishes docs while `latest` is itself a prerelease, it will do the right thing without further changes.

The projects 0.7.1 actually fixes are the ones that have never cut a stable release — zio-dynamodb, zio-prelude, zio-direct, zio-amqp — where the old behaviour froze `latest` and hid their docs from dependency bots.

## Verification

- `sbt "++2.13; check"` passes (`ciCheck`, `docs/checkReadme`, `docs/ciCheckGithubWorkflow`).
- `sbt ciGenerateGithubWorkflow` and `sbt docs/generateReadme` produce no changes — 0.7.1 does not alter the generated workflow or README, so this is a one-line diff.
