### PR TITLE
fix(opentelemetry): record causes as exceptions in logs

### DIFF
--- a/modules/opentelemetry/core/src/main/scala/zio/telemetry/opentelemetry/core/logs/Logger.scala
+++ b/modules/opentelemetry/core/src/main/scala/zio/telemetry/opentelemetry/core/logs/Logger.scala
@@ -46,6 +46,13 @@ private[opentelemetry] object Logger {
         builder.setSeverityText(logLevel.label)
         builder.setSeverity(severityMapping(logLevel))
         annotations.foreach { case (k, v) => builder.setAttribute(AttributeKey.stringKey(k), v) }
+        if (!cause.isEmpty) {
+          val throwable = cause.failureOption match {
+            case Some(t: Throwable) => t
+            case _                  => FiberFailure(cause)
+          }
+          val _         = builder.setException(throwable)
+        }
 
         ctxStorage match {
           case cs: ContextStorage.ZIOFiberRef             =>

--- a/modules/opentelemetry/core/src/main/scala/zio/telemetry/opentelemetry/core/logs/Logger.scala
+++ b/modules/opentelemetry/core/src/main/scala/zio/telemetry/opentelemetry/core/logs/Logger.scala
@@ -47,11 +47,7 @@ private[opentelemetry] object Logger {
         builder.setSeverity(severityMapping(logLevel))
         annotations.foreach { case (k, v) => builder.setAttribute(AttributeKey.stringKey(k), v) }
         if (!cause.isEmpty) {
-          val throwable = cause.failureOption match {
-            case Some(t: Throwable) => t
-            case _                  => FiberFailure(cause)
-          }
-          val _         = builder.setException(throwable)
+          val _ = builder.setException(causeToThrowable(cause))
         }
 
         ctxStorage match {
@@ -63,6 +59,13 @@ private[opentelemetry] object Logger {
 
         builder.emit()
       }
+
+      private def causeToThrowable(cause: Cause[Any]): Throwable =
+        (cause.failures, cause.defects, cause.isInterrupted) match {
+          case ((failure: Throwable) :: Nil, Nil, false) => failure
+          case (Nil, defect :: Nil, false)               => defect
+          case _                                         => FiberFailure(cause)
+        }
 
       private def severityMapping(level: LogLevel): Severity =
         level match {

--- a/modules/opentelemetry/main/src/test/scala/zio/telemetry/opentelemetry/core/logs/LoggerTest.scala
+++ b/modules/opentelemetry/main/src/test/scala/zio/telemetry/opentelemetry/core/logs/LoggerTest.scala
@@ -63,6 +63,34 @@ object LoggerTest extends ZIOSpecDefault {
             assert(attributes.get("exception.message"))(isSome(equalTo("boom"))) &&
             assert(attributes.get("exception.stacktrace"))(isSome(containsString("IllegalArgumentException: boom")))
         }.provide(LoggerTestkit.inMemory("exception cause"), OpenTelemetryTestkit.ctxStorageZioFiberRef),
+        test("defect cause") {
+          val exception = new IllegalStateException("boom")
+
+          for {
+            loggerTestkit <- ZIO.service[LoggerTestkit]
+            _             <- ZIO.logErrorCause("test", Cause.die(exception))
+            logRecords    <- loggerTestkit.getFinishedLogRecords
+            attributes     = logRecords.head.attributes.asMap
+          } yield assert(attributes.get("exception.type"))(isSome(equalTo("java.lang.IllegalStateException"))) &&
+            assert(attributes.get("exception.message"))(isSome(equalTo("boom"))) &&
+            assert(attributes.get("exception.stacktrace"))(isSome(containsString("IllegalStateException: boom")))
+        }.provide(LoggerTestkit.inMemory("defect cause"), OpenTelemetryTestkit.ctxStorageZioFiberRef),
+        test("composite cause") {
+          val first  = new IllegalArgumentException("first")
+          val second = new IllegalStateException("second")
+
+          for {
+            loggerTestkit <- ZIO.service[LoggerTestkit]
+            _             <- ZIO.logErrorCause("test", Cause.fail(first) && Cause.fail(second))
+            logRecords    <- loggerTestkit.getFinishedLogRecords
+            attributes     = logRecords.head.attributes.asMap
+          } yield assert(attributes.get("exception.type"))(isSome(equalTo("zio.FiberFailure"))) &&
+            assert(attributes.get("exception.stacktrace"))(
+              isSome(
+                containsString("IllegalArgumentException: first") && containsString("IllegalStateException: second")
+              )
+            )
+        }.provide(LoggerTestkit.inMemory("composite cause"), OpenTelemetryTestkit.ctxStorageZioFiberRef),
         test("multiple loggers") {
           def logRecordsZIO(message: String) =
             for {

--- a/modules/opentelemetry/main/src/test/scala/zio/telemetry/opentelemetry/core/logs/LoggerTest.scala
+++ b/modules/opentelemetry/main/src/test/scala/zio/telemetry/opentelemetry/core/logs/LoggerTest.scala
@@ -49,6 +49,20 @@ object LoggerTest extends ZIOSpecDefault {
           LoggerTestkit.inMemory("filter log level", LogLevel.Warning),
           OpenTelemetryTestkit.ctxStorageZioFiberRef
         ),
+        test("exception cause") {
+          val exception = new IllegalArgumentException("boom")
+
+          for {
+            loggerTestkit <- ZIO.service[LoggerTestkit]
+            _             <- ZIO.logErrorCause("test", Cause.fail(exception))
+            logRecords    <- loggerTestkit.getFinishedLogRecords
+            record         = logRecords.head
+            attributes     = record.attributes.asMap
+          } yield assert(logRecords.length)(equalTo(1)) &&
+            assert(attributes.get("exception.type"))(isSome(equalTo("java.lang.IllegalArgumentException"))) &&
+            assert(attributes.get("exception.message"))(isSome(equalTo("boom"))) &&
+            assert(attributes.get("exception.stacktrace"))(isSome(containsString("IllegalArgumentException: boom")))
+        }.provide(LoggerTestkit.inMemory("exception cause"), OpenTelemetryTestkit.ctxStorageZioFiberRef),
         test("multiple loggers") {
           def logRecordsZIO(message: String) =
             for {


### PR DESCRIPTION
The OpenTelemetry `ZLogger` receives a `Cause[Any]`, but currently ignores it when emitting the log record. As a result, logs produced with `ZIO.logErrorCause` omit the standard OpenTelemetry exception attributes:

- `exception.type`
- `exception.message`
- `exception.stacktrace`

This change passes non-empty causes to `LogRecordBuilder.setException` and handles the different ZIO cause shapes explicitly:

- A single typed `Throwable` keeps its original exception details.
- A single defect keeps its original exception details.
- Composite or interrupted causes use `FiberFailure`, preserving the complete ZIO cause.

Regression tests cover a typed exception, a defect, and a composite cause. The composite test verifies that both exceptions remain present in `exception.stacktrace`.

Tested with Scala 2.12, 2.13, and 3.